### PR TITLE
fix: png 16bit conversion crash, null guard added to handle if native returns null

### DIFF
--- a/lib/src/darwin/native.dart
+++ b/lib/src/darwin/native.dart
@@ -212,8 +212,16 @@ final class ImageConverterDarwin implements ImageConverterPlatform {
         );
       }
 
-      final bitsPerComponent = CGImageGetBitsPerComponent(originalImage);
-      final bitmapInfo = CGImageGetBitmapInfo(originalImage);
+      // FIX: Always use 8 bits/component for the output bitmap context.
+      // The source may be 16bpc (e.g. 16-bit PNGs), which CGBitmapContextCreate
+      // rejects for certain alpha/byte-order combinations, returning NULL.
+      // Since the output is always 8-bit (JPEG/PNG for display), 8bpc is correct.
+      const bitsPerComponent = 8;
+
+      // We cannot reuse the source image's bitmapInfo because it may contain
+      // 16-bit byte-order flags (e.g. kCGImageByteOrder16Little = 0x1000)
+      // that are incompatible with 8bpc, causing CGBitmapContextCreate to fail.
+      const bitmapInfo = 1; // kCGImageAlphaPremultipliedLast
 
       context = CGBitmapContextCreate(
         nullptr,
@@ -251,7 +259,13 @@ final class ImageConverterDarwin implements ImageConverterPlatform {
       }
       return resizedImage;
     } finally {
-      if (context != null) CFRelease(context.cast());
+      // FIX: Check both Dart null AND FFI nullptr before releasing.
+      // CFRelease(NULL) is a fatal error in CoreFoundation (brk #0x1).
+      // The Dart variable `context` is non-null once assigned, but the
+      // native pointer may be nullptr if CGBitmapContextCreate failed.
+      if (context != null && context != nullptr) {
+        CFRelease(context.cast());
+      }
     }
   }
 }


### PR DESCRIPTION
On iOS I was converting a 16-bit PNG and received a crash. CGBitmapContextCreate() does not support 16-bit and returned null. That combined with no check for 

> Process 21788 stopped
> * thread 29, name = 'DartWorker', stop reason = EXC_BREAKPOINT (code=1, subcode=0x196ad365c)
>     frame #0: 0x0000000196ad365c CoreFoundation`CFRelease.cold.1 + 16
> CoreFoundation`CFRelease.cold.1:
> ->  0x196ad365c <+16>: brk    #0x1
> 
> CoreFoundation`__CFStringCollectionCopy.cold.1:
> 0x196ad3660 <+0>:  adrp   x8, 422734
> 0x196ad3664 <+4>:  adrp   x9, 458
> 0x196ad3668 <+8>:  add    x9, x9, #0x292            ; "*** __CFStringCollectionCopy() called with NULL ***"
>   Target 0: (Runner) stopped.

FIX: 
1. Force 8-bit eliminates any/all unsupported issues going forward, since all output formats produce 8-bit images, there is no need to create 16-bit context.
2. Added null check as a guard for any future if CGBitmapContextCreate returns null

FYI, I put a lot of comments in my patch. Feel free to remove/modify/summarize how you prefer. I left it there 

PS.
Thank you for a native FFI library! very modern
I have created a new flutter app with support for iOS, macOS, Android, and Windows. If want to check it out (in beta not released yet), go to letusmsg.com