### PR TITLE
fix: render all Darwin conversions through a fixed sRGB context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.0
+
+* Fix iOS/macOS crash when resizing 16-bit, grayscale, CMYK, or indexed images (#36).
+* Normalize iOS/macOS output to 8-bit sRGB. 16-bit and wide-gamut (e.g. Display P3) sources are no longer preserved, and output no longer depends on whether a resize occurred (behavior change).
+
 ## 1.0.6
 
 * Fix lint rule.

--- a/example/integration_test/app_test.dart
+++ b/example/integration_test/app_test.dart
@@ -419,10 +419,155 @@ void main() {
       }
     });
   });
+
+  group('Conversion across source pixel formats', () {
+    final sources = <(String, img.Format, int)>[
+      ('8-bit grayscale', img.Format.uint8, 1),
+      ('8-bit RGB', img.Format.uint8, 3),
+      ('8-bit RGBA', img.Format.uint8, 4),
+      ('16-bit grayscale', img.Format.uint16, 1),
+      ('16-bit RGB', img.Format.uint16, 3),
+      ('16-bit RGBA', img.Format.uint16, 4),
+    ];
+
+    for (final (label, format, channels) in sources) {
+      test('$label resizes and stays coherent', () async {
+        final input = _makePng(format: format, numChannels: channels);
+
+        final converted = await ImageConverter.convert(
+          inputData: input,
+          format: OutputFormat.png,
+          resizeMode: ExactResizeMode(width: 64, height: 64),
+        );
+
+        expect(converted, isNotEmpty);
+        final decoded = img.decodeImage(converted);
+        expect(decoded, isNotNull);
+        expect(decoded!.width, 64);
+        expect(decoded.height, 64);
+
+        final info = _inspect(decoded);
+        expect(info.varies, isTrue, reason: '$label lost its gradient');
+        if (channels == 1) {
+          expect(info.achromatic, isTrue, reason: '$label is not gray anymore');
+        }
+      });
+    }
+
+    test('semi-transparent RGBA keeps its alpha through resize', () async {
+      final input = _makePng(
+        format: img.Format.uint8,
+        numChannels: 4,
+        transparent: true,
+      );
+
+      final converted = await ImageConverter.convert(
+        inputData: input,
+        format: OutputFormat.png,
+        resizeMode: ExactResizeMode(width: 64, height: 64),
+      );
+
+      final decoded = img.decodeImage(converted);
+      expect(decoded, isNotNull);
+      expect(
+        _inspect(decoded!).alphaVaries,
+        isTrue,
+        reason: 'transparency was not preserved',
+      );
+    });
+
+    test('indexed (palette) PNG resizes without crashing', () async {
+      final base = img.Image(width: 128, height: 128, numChannels: 3);
+      for (final pixel in base) {
+        final v = (((pixel.x + pixel.y) / 254) * 255).round();
+        pixel
+          ..r = v
+          ..g = v ~/ 2
+          ..b = 255 - v;
+      }
+      final input = img.encodePng(img.quantize(base, numberOfColors: 16));
+
+      final converted = await ImageConverter.convert(
+        inputData: input,
+        format: OutputFormat.png,
+        resizeMode: ExactResizeMode(width: 64, height: 64),
+      );
+
+      final decoded = img.decodeImage(converted);
+      expect(decoded, isNotNull);
+      expect(decoded!.width, 64);
+      expect(decoded.height, 64);
+      expect(_inspect(decoded).varies, isTrue);
+    });
+
+    test('16-bit source converts at original size (no-resize path)', () async {
+      final input = _makePng(format: img.Format.uint16, numChannels: 3);
+
+      final converted = await ImageConverter.convert(
+        inputData: input,
+        format: OutputFormat.png,
+        resizeMode: const OriginalResizeMode(),
+      );
+
+      final decoded = img.decodeImage(converted);
+      expect(decoded, isNotNull);
+      expect(decoded!.width, 128);
+      expect(decoded.height, 128);
+    });
+  });
 }
 
 /// Load an image from assets and return as [Uint8List]
 Future<Uint8List> _loadAssetImage(String assetPath) async {
   final data = await rootBundle.load(assetPath);
   return data.buffer.asUint8List();
+}
+
+/// Build a PNG with the given bit depth and channel count. When [transparent]
+/// the alpha channel ramps 0..max across X so transparency is exercised.
+Uint8List _makePng({
+  required img.Format format,
+  required int numChannels,
+  bool transparent = false,
+}) {
+  final image = img.Image(
+    width: 128,
+    height: 128,
+    format: format,
+    numChannels: numChannels,
+  );
+  final maxValue = format == img.Format.uint16 ? 65535 : 255;
+  for (final pixel in image) {
+    final v = (((pixel.x + pixel.y) / 254) * maxValue).round();
+    pixel
+      ..r = v
+      ..g = v
+      ..b = v
+      ..a = transparent ? ((pixel.x / 127) * maxValue).round() : maxValue;
+  }
+  return img.encodePng(image);
+}
+
+/// Sparse-sample [im]: whether it varies, stays achromatic (r==g==b), and
+/// whether its alpha varies. Tolerant — exact values differ per platform.
+({bool varies, bool achromatic, bool alphaVaries}) _inspect(img.Image im) {
+  int? firstLum;
+  int? firstAlpha;
+  var varies = false;
+  var achromatic = true;
+  var alphaVaries = false;
+  for (var y = 0; y < im.height; y += 8) {
+    for (var x = 0; x < im.width; x += 8) {
+      final p = im.getPixel(x, y);
+      final r = p.r.toInt();
+      final g = p.g.toInt();
+      final b = p.b.toInt();
+      final a = p.a.toInt();
+      final lum = r + g + b;
+      if ((firstLum ??= lum) != lum) varies = true;
+      if ((r - g).abs() > 4 || (r - b).abs() > 4) achromatic = false;
+      if ((firstAlpha ??= a) != a) alphaVaries = true;
+    }
+  }
+  return (varies: varies, achromatic: achromatic, alphaVaries: alphaVaries);
 }

--- a/ffigen.dart
+++ b/ffigen.dart
@@ -27,11 +27,10 @@ final config = FfiGenerator(
     'CGImageDestinationAddImage',
     'CGImageDestinationFinalize',
     // CGImage operations
-    'CGImageGetBitsPerComponent',
-    'CGImageGetBitmapInfo',
-    'CGImageGetColorSpace',
     'CGImageGetWidth',
     'CGImageGetHeight',
+    // CGColorSpace operations
+    'CGColorSpaceCreateWithName',
     // CGContext operations
     'CGContextDrawImage',
     'CGContextSetInterpolationQuality',
@@ -46,7 +45,9 @@ final config = FfiGenerator(
     'kCGImageDestinationLossyCompressionQuality',
     'kCFTypeDictionaryValueCallBacks',
     'kCFTypeDictionaryKeyCallBacks',
+    'kCGColorSpaceSRGB',
   }),
+  enums: Enums.includeSet({'CGImageAlphaInfo'}),
   typedefs: Typedefs.includeSet({
     'CFDataRef',
     'CFDictionaryRef',

--- a/lib/src/darwin/bindings.g.dart
+++ b/lib/src/darwin/bindings.g.dart
@@ -61,20 +61,19 @@ external int CFDataGetLength(CFDataRef theData);
 @ffi.Native<ffi.Pointer<ffi.UnsignedChar> Function(CFDataRef)>()
 external ffi.Pointer<ffi.UnsignedChar> CFDataGetBytePtr(CFDataRef theData);
 
+@ffi.Native<ffi.Pointer<objc.CFString>>()
+external ffi.Pointer<objc.CFString> kCGColorSpaceSRGB;
+
+@ffi.Native<CGColorSpaceRef Function(ffi.Pointer<objc.CFString>)>()
+external CGColorSpaceRef CGColorSpaceCreateWithName(
+  ffi.Pointer<objc.CFString> name,
+);
+
 @ffi.Native<ffi.Size Function(CGImageRef)>()
 external int CGImageGetWidth(CGImageRef image);
 
 @ffi.Native<ffi.Size Function(CGImageRef)>()
 external int CGImageGetHeight(CGImageRef image);
-
-@ffi.Native<ffi.Size Function(CGImageRef)>()
-external int CGImageGetBitsPerComponent(CGImageRef image);
-
-@ffi.Native<CGColorSpaceRef Function(CGImageRef)>()
-external CGColorSpaceRef CGImageGetColorSpace(CGImageRef image);
-
-@ffi.Native<ffi.Uint32 Function(CGImageRef)>()
-external int CGImageGetBitmapInfo(CGImageRef image);
 
 @ffi.Native<ffi.Void Function(CGContextRef, objc.CGRect, CGImageRef)>()
 external void CGContextDrawImage(
@@ -275,6 +274,32 @@ typedef CGColorSpaceRef = ffi.Pointer<CGColorSpace>;
 final class CGImage extends ffi.Opaque {}
 
 typedef CGImageRef = ffi.Pointer<CGImage>;
+
+enum CGImageAlphaInfo {
+  kCGImageAlphaNone(0),
+  kCGImageAlphaPremultipliedLast(1),
+  kCGImageAlphaPremultipliedFirst(2),
+  kCGImageAlphaLast(3),
+  kCGImageAlphaFirst(4),
+  kCGImageAlphaNoneSkipLast(5),
+  kCGImageAlphaNoneSkipFirst(6),
+  kCGImageAlphaOnly(7);
+
+  final int value;
+  const CGImageAlphaInfo(this.value);
+
+  static CGImageAlphaInfo fromValue(int value) => switch (value) {
+    0 => kCGImageAlphaNone,
+    1 => kCGImageAlphaPremultipliedLast,
+    2 => kCGImageAlphaPremultipliedFirst,
+    3 => kCGImageAlphaLast,
+    4 => kCGImageAlphaFirst,
+    5 => kCGImageAlphaNoneSkipLast,
+    6 => kCGImageAlphaNoneSkipFirst,
+    7 => kCGImageAlphaOnly,
+    _ => throw ArgumentError('Unknown value for CGImageAlphaInfo: $value'),
+  };
+}
 
 sealed class CGBitmapInfo {
   static const kCGBitmapAlphaInfoMask = 31;

--- a/lib/src/darwin/native.dart
+++ b/lib/src/darwin/native.dart
@@ -9,6 +9,14 @@ import 'package:platform_image_converter/src/image_converter_platform_interface.
 import 'package:platform_image_converter/src/output_format.dart';
 import 'package:platform_image_converter/src/output_resize.dart';
 
+/// Releases a CoreFoundation object, skipping both Dart `null` and FFI
+/// `nullptr`. `CFRelease(NULL)` is a fatal error.
+void _releaseCF(Pointer<NativeType>? ref) {
+  if (ref != null && ref != nullptr) {
+    CFRelease(ref.cast());
+  }
+}
+
 /// iOS/macOS image converter using ImageIO framework.
 ///
 /// Implements image conversion for iOS 14+ and macOS 10.15+ platforms using
@@ -83,11 +91,10 @@ final class ImageConverterDarwin implements ImageConverterPlatform {
         originalHeight,
       );
 
-      if (newWidth == originalWidth && newHeight == originalHeight) {
-        imageToEncode = originalImage;
-      } else {
-        imageToEncode = _resizeImage(originalImage, newWidth, newHeight);
-      }
+      // Always render through the sRGB context (even at the original size) so
+      // output is independent of whether a resize happened, matching the
+      // Android/Web backends which always produce 8-bit sRGB.
+      imageToEncode = _renderToSRGB(originalImage, newWidth, newHeight);
 
       if (imageToEncode == nullptr) {
         throw const ImageConversionException(
@@ -158,15 +165,13 @@ final class ImageConverterDarwin implements ImageConverterPlatform {
       return Uint8List.fromList(bytePtr.cast<Uint8>().asTypedList(length));
     } finally {
       if (inputPtr != null) calloc.free(inputPtr);
-      if (cfData != null) CFRelease(cfData.cast());
-      if (imageSource != null) CFRelease(imageSource.cast());
-      if (imageToEncode != null && imageToEncode != originalImage) {
-        CFRelease(imageToEncode.cast());
-      }
-      if (originalImage != null) CFRelease(originalImage.cast());
-      if (outputData != null) CFRelease(outputData.cast());
-      if (destination != null) CFRelease(destination.cast());
-      if (properties != null) CFRelease(properties.cast());
+      _releaseCF(cfData);
+      _releaseCF(imageSource);
+      _releaseCF(imageToEncode);
+      _releaseCF(originalImage);
+      _releaseCF(outputData);
+      _releaseCF(destination);
+      _releaseCF(properties);
     }
   }
 
@@ -202,27 +207,29 @@ final class ImageConverterDarwin implements ImageConverterPlatform {
     });
   }
 
-  CGImageRef _resizeImage(CGImageRef originalImage, int width, int height) {
+  /// Draws [originalImage] into a fixed 8-bpc sRGB premultiplied-RGBA context at
+  /// [width]x[height], normalizing any source format (16-bpc / grayscale / CMYK
+  /// / indexed sources otherwise make CGBitmapContextCreate return NULL) and
+  /// scaling in the same pass. Output is always 8-bit sRGB.
+  CGImageRef _renderToSRGB(CGImageRef originalImage, int width, int height) {
+    CGColorSpaceRef? colorSpace;
     CGContextRef? context;
     try {
-      final colorSpace = CGImageGetColorSpace(originalImage);
+      colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
       if (colorSpace == nullptr) {
         throw const ImageConversionException(
-          'Failed to get color space from image for resizing.',
+          'Failed to create sRGB color space for resizing.',
         );
       }
-
-      final bitsPerComponent = CGImageGetBitsPerComponent(originalImage);
-      final bitmapInfo = CGImageGetBitmapInfo(originalImage);
 
       context = CGBitmapContextCreate(
         nullptr,
         width,
         height,
-        bitsPerComponent,
+        8, // bitsPerComponent
         0, // bytesPerRow (0 means calculate automatically)
         colorSpace,
-        bitmapInfo,
+        CGImageAlphaInfo.kCGImageAlphaPremultipliedLast.value,
       );
       if (context == nullptr) {
         throw const ImageConversionException(
@@ -251,7 +258,8 @@ final class ImageConverterDarwin implements ImageConverterPlatform {
       }
       return resizedImage;
     } finally {
-      if (context != null) CFRelease(context.cast());
+      _releaseCF(context);
+      _releaseCF(colorSpace);
     }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: platform_image_converter
 description: "A high-performance Flutter plugin for cross-platform image format conversion using native APIs."
-version: 1.0.6
+version: 1.1.0
 homepage: https://github.com/koji-1009/platform_image_converter
 topics:
   - image


### PR DESCRIPTION
Fixes #36.

## Problem
Resizing certain images crashed on iOS/macOS. `CGBitmapContextCreate` accepts only a fixed set of `(color space, bits-per-component, alpha)` combinations, so reusing the source image's own format returned `NULL` for 16-bit, grayscale, CMYK, and indexed PNGs — and the cleanup then called `CFRelease(NULL)`, a fatal CoreFoundation error (`brk 1`).

## Changes
- `convert()` always renders through a fixed **8-bpc sRGB premultiplied-RGBA** context (`_renderToSRGB`), even at the original size, so CoreGraphics converts any source and output is uniformly 8-bit sRGB regardless of whether a resize happened — matching the Android (`ARGB_8888`) and Web (Canvas) backends.
- Consolidated `CFRelease` into a NULL-safe `_releaseCF` helper, so the same crash cannot recur on other error paths.
- ffigen: added `CGColorSpaceCreateWithName` + `kCGColorSpaceSRGB`; removed the now-unused `CGImageGet{ColorSpace,BitsPerComponent,BitmapInfo}`.
- Added integration tests across 8-/16-bit × grayscale/RGB/RGBA, plus semi-transparent RGBA, indexed-palette, and the no-resize path — asserting color/alpha, not just dimensions.

## ⚠️ Behavior change (1.1.0)
iOS/macOS output is now normalized to **8-bit sRGB**; 16-bit and wide-gamut (e.g. Display P3) sources are **no longer preserved**, including on the no-resize path. This makes Darwin output consistent with the other platforms.

## Testing
iOS simulator: `resize_pixel_format_test.dart` 9/9, `app_test.dart` 17/17; `dart analyze` clean.

## Credit
Builds on #30 by @j3g (crash report + initial fix). #30 left open intentionally; this supersedes it with a broader color-space fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
