### PR TITLE
docs: fix stray escape in ImageConverterAndroid doc comment

### DIFF
--- a/lib/src/android/native.dart
+++ b/lib/src/android/native.dart
@@ -10,7 +10,8 @@ import 'package:platform_image_converter/src/output_resize.dart';
 /// Android image converter using BitmapFactory and Bitmap compression.
 ///
 /// Implements image conversion for Android 9+ (API level 28+) platforms using
-/// BitmapFactory for decoding and Bitmap.compress for encoding via JNI.\n///
+/// BitmapFactory for decoding and Bitmap.compress for encoding via JNI.
+///
 /// **Features:**
 /// - Supports JPEG, PNG, WebP, GIF, BMP input formats
 /// - Can read HEIC files (Android 9+)


### PR DESCRIPTION
The `ImageConverterAndroid` class doc contained a literal `\n///` (a stray escape) instead of a blank doc line, so it rendered as raw `\n///` in dartdoc. Replaced it with a proper blank comment line.

Docs-only; no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
