### PR TITLE
ci: cancel redundant runs and target app_test.dart explicitly

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   drive_android:
     name: Android
@@ -33,7 +37,7 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           arch: x86_64
-          script: flutter test integration_test -d android
+          script: flutter test integration_test/app_test.dart -d android
           working-directory: example
 
   drive_ios:
@@ -60,7 +64,7 @@ jobs:
         run: flutter build ios --simulator --target=integration_test/app_test.dart
       - name: Run flutter integration tests
         working-directory: example
-        run: flutter test integration_test -d iphone
+        run: flutter test integration_test/app_test.dart -d iphone
 
   drive_macos:
     name: macOS
@@ -73,7 +77,7 @@ jobs:
       - uses: koji-1009/setup-flutter@7e963b8ba06dfc8ea08c6d16371473b4a8b32819 # v1.1.5
       - name: Run Flutter Integration tests
         working-directory: example
-        run: flutter test integration_test -d macos
+        run: flutter test integration_test/app_test.dart -d macos
 
   drive_web:
     name: Web
@@ -90,4 +94,4 @@ jobs:
           chromedriver --port=4444 &
       - name: Run Flutter Integration tests
         working-directory: example
-        run: flutter drive --driver=test_driver/integration_test.dart --target=integration_test/app_test.dart -d web-server \
+        run: flutter drive --driver=test_driver/integration_test.dart --target=integration_test/app_test.dart -d web-server

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -3,6 +3,10 @@ name: Pull Request Checks
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-slim

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit_tests:
     runs-on: ubuntu-slim


### PR DESCRIPTION
Workflow improvements (no package/code change):

- **Concurrency**: add a `concurrency` group with `cancel-in-progress` to all three workflows, so a new push to a branch/PR cancels its outdated in-progress runs instead of running the full (macOS/iOS/Android) matrix redundantly.
- **Explicit target**: run the integration tests against `integration_test/app_test.dart` on Android/iOS/macOS — matching Web (`flutter drive --target=…`) and the iOS pre-build target. All platforms now reference the single entry file, so macOS no longer depends on whole-directory launch behaviour (which fails once a second integration_test file exists).
- **Cleanup**: drop a dangling trailing `\` in the Web `flutter drive` command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
