### PR TITLE
chore: validate resize dimensions and tidy docs/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ The iOS/macOS implementation uses the [ImageIO](https://developer.apple.com/docu
 3. **Encoding**: `CGImageDestinationCreateWithData` encodes the final `CGImage` to the target format.
 4. **Quality**: Uses `kCGImageDestinationLossyCompressionQuality` for JPEG/HEIC.
 
+**Note:** Every conversion renders through a fixed 8-bit sRGB context — even when no resize is requested — so iOS/macOS output is always 8-bit sRGB. 16-bit and wide-gamut (e.g. Display P3) sources are not preserved, keeping output consistent with the Android and Web backends.
+
 ### Android Implementation
 
 The Android implementation uses [BitmapFactory](https://developer.android.com/reference/android/graphics/BitmapFactory) and [Bitmap.compress](https://developer.android.com/reference/android/graphics/Bitmap#compress(android.graphics.Bitmap.CompressFormat,%20int,%20java.io.OutputStream)):

--- a/lib/src/android/native.dart
+++ b/lib/src/android/native.dart
@@ -9,7 +9,7 @@ import 'package:platform_image_converter/src/output_resize.dart';
 
 /// Android image converter using BitmapFactory and Bitmap compression.
 ///
-/// Implements image conversion for Android 9+ (API level 28+) platforms using
+/// Implements image conversion on Android using
 /// BitmapFactory for decoding and Bitmap.compress for encoding via JNI.
 ///
 /// **Features:**

--- a/lib/src/image_converter_platform_interface.dart
+++ b/lib/src/image_converter_platform_interface.dart
@@ -22,7 +22,7 @@ abstract interface class ImageConverterPlatform {
   /// **Parameters:**
   /// - [inputData]: Raw bytes of the image to convert
   /// - [format]: Target [OutputFormat] (default: [OutputFormat.jpeg])
-  /// - [quality]: Compression quality 1-100 for lossy formats (default: 95)
+  /// - [quality]: Compression quality 1-100 for lossy formats (default: 100)
   /// - [resizeMode]: The resize mode to apply to the image.
   ///
   /// **Returns:** Converted image data as [Uint8List]

--- a/lib/src/output_resize.dart
+++ b/lib/src/output_resize.dart
@@ -21,7 +21,8 @@ class OriginalResizeMode extends ResizeMode {
 /// A resize mode that resizes the image to exact dimensions,
 /// possibly changing the aspect ratio.
 class ExactResizeMode extends ResizeMode {
-  const ExactResizeMode({required this.width, required this.height});
+  const ExactResizeMode({required this.width, required this.height})
+    : assert(width > 0 && height > 0, 'width and height must be positive');
 
   /// The target width for the resized image.
   final int width;
@@ -42,7 +43,9 @@ class ExactResizeMode extends ResizeMode {
 /// scaled up.
 class FitResizeMode extends ResizeMode {
   const FitResizeMode({this.width, this.height})
-    : assert(width != null || height != null);
+    : assert(width != null || height != null),
+      assert((width ?? 1) > 0, 'width must be positive'),
+      assert((height ?? 1) > 0, 'height must be positive');
 
   /// The maximum width for the resized image.
   final int? width;

--- a/test/output_resize_test.dart
+++ b/test/output_resize_test.dart
@@ -109,7 +109,7 @@ void main() {
       expect(height, originalHeight);
     });
 
-    test('nandles very large images', () {
+    test('handles very large images', () {
       const originalWidth = 10000;
       const originalHeight = 5000;
 
@@ -120,6 +120,22 @@ void main() {
       );
       expect(width, 100);
       expect(height, 50);
+    });
+
+    test('ExactResizeMode rejects non-positive dimensions', () {
+      expect(
+        () => ExactResizeMode(width: 0, height: 10),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => ExactResizeMode(width: 10, height: -1),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('FitResizeMode rejects non-positive dimensions', () {
+      expect(() => FitResizeMode(width: 0), throwsA(isA<AssertionError>()));
+      expect(() => FitResizeMode(height: -5), throwsA(isA<AssertionError>()));
     });
   });
 }


### PR DESCRIPTION
Low-impact cleanup; no behavior change on valid input:

- **Resize validation**: `ExactResizeMode` and `FitResizeMode` now assert positive dimensions (with unit tests), so a 0/negative size fails with a clear error instead of an opaque failure deep in the native resize.
- **Docs**: platform-interface `quality` default corrected to 100 (was 95); the Android converter doc no longer overstates the minimum OS (only HEIC input needs Android 9+); README notes that iOS/macOS output is normalized to 8-bit sRGB (16-bit / wide-gamut sources aren't preserved).
- **Test**: fix a test-name typo (`nandles` → `handles`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
