### PR TITLE
fix(web): use high-quality image smoothing for resizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1
+
+* Web: render resizes with `imageSmoothingQuality = 'high'` so downscaled output quality matches the iOS/macOS (`kCGInterpolationHigh`) and Android (`filter: true`) backends.
+
 ## 1.2.0
 
 * Upgrade the `jni` dependency to `^1.0.0` and regenerate the Android bindings with `jnigen` 0.16.0. The minimum `jni` version is now 1.0.0 (previously 0.15.2); this major bump of a direct dependency may affect dependency resolution for consumers that also depend on `jni`.

--- a/lib/src/web/web.dart
+++ b/lib/src/web/web.dart
@@ -75,7 +75,9 @@ final class ImageConverterWeb implements ImageConverterPlatform {
     canvas.width = destWidth;
     canvas.height = destHeight;
 
-    final ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
+    final ctx = canvas.getContext('2d') as CanvasRenderingContext2D
+      ..imageSmoothingEnabled = true
+      ..imageSmoothingQuality = 'high';
     ctx.drawImage(img, 0, 0, destWidth, destHeight);
 
     final encodeCompleter = Completer<Blob>();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: platform_image_converter
 description: "A high-performance Flutter plugin for cross-platform image format conversion using native APIs."
-version: 1.2.0
+version: 1.2.1
 homepage: https://github.com/koji-1009/platform_image_converter
 topics:
   - image


### PR DESCRIPTION
## Summary

Web resizes now render with `imageSmoothingQuality = 'high'` (and `imageSmoothingEnabled = true`) on the 2D context before `drawImage`, so downscaled output quality matches the native backends — iOS/macOS use `kCGInterpolationHigh`, Android uses `filter: true`. Previously the Web canvas used the browser default (`'low'`), leaving Web downscales softer/more aliased than the other platforms.

Releases as **1.2.1** (patch: behavior-improving, no API change).

## Testing

- `dart analyze` (lib): no issues.
- CI runs the full integration suite (`example/integration_test/app_test.dart`) on Android/iOS/macOS/Web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
