### PR TITLE
feat(windows): image conversion via Windows Imaging Component (WIC), with HEIC output

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -79,6 +79,19 @@ jobs:
         working-directory: example
         run: flutter test integration_test/app_test.dart -d macos
 
+  drive_windows:
+    name: Windows
+    runs-on: windows-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: koji-1009/setup-flutter@7e963b8ba06dfc8ea08c6d16371473b4a8b32819 # v1.1.5
+      - name: Run Flutter Integration tests
+        working-directory: example
+        run: flutter test integration_test/app_test.dart -d windows
+
   drive_web:
     name: Web
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,4 +19,4 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: koji-1009/setup-flutter@7e963b8ba06dfc8ea08c6d16371473b4a8b32819 # v1.1.5
-      - run: dart test
+      - run: flutter test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+* Add Windows support via the Windows Imaging Component (WIC), bound directly with `dart:ffi` (no native build step). JPEG and PNG output are supported with the same resizing modes and quality control as the other platforms. HEIC output is also supported where the OS ships the HEVC/HEIF codec (Windows 11 22H2+ out of the box; older Windows via the Store "HEVC Video Extensions") — when absent, HEIC throws `UnsupportedError`. WebP output is not supported (Windows has a WebP decoder but no encoder). As on the Darwin backend, every source is normalized to a fixed 8-bit surface before encoding.
+
 ## 1.2.1
 
 * Web: render resizes with `imageSmoothingQuality = 'high'` so downscaled output quality matches the iOS/macOS (`kCGInterpolationHigh`) and Android (`filter: true`) backends.

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![pub package](https://img.shields.io/pub/v/platform_image_converter.svg)](https://pub.dev/packages/platform_image_converter)
 [![GitHub license](https://img.shields.io/github/license/koji-1009/platform_image_converter)](https://github.com/koji-1009/platform_image_converter/blob/main/LICENSE)
 
-A high-performance Flutter plugin for cross-platform image format conversion and resizing using native APIs on iOS, macOS, Android, and Web.
+A high-performance Flutter plugin for cross-platform image format conversion and resizing using native APIs on iOS, macOS, Android, Windows, and Web.
 
 ## Features
 
-- 🖼️ **Versatile Format Conversion**: Supports conversion between JPEG, PNG, and WebP. It also handles HEIC/HEIF, allowing conversion *from* HEIC on all supported platforms and *to* HEIC on iOS/macOS.
+- 🖼️ **Versatile Format Conversion**: Supports conversion between JPEG, PNG, and WebP. It also handles HEIC/HEIF, allowing conversion *from* HEIC on all supported platforms and *to* HEIC on iOS/macOS and Windows (where the OS HEVC/HEIF codec is present).
 - 📐 **High-Quality Resizing**: Resize images with different modes (`Fit`, `Exact`) while maintaining aspect ratio or targeting specific dimensions.
-- ⚡ **Native Performance**: Achieves high speed by using platform-native APIs directly: `ImageIO` and `Core Graphics` on iOS/macOS, `BitmapFactory` and `Bitmap` methods on Android, and the `Canvas API` on the Web.
+- ⚡ **Native Performance**: Achieves high speed by using platform-native APIs directly: `ImageIO` and `Core Graphics` on iOS/macOS, `BitmapFactory` and `Bitmap` methods on Android, the `Windows Imaging Component` (WIC) on Windows, and the `Canvas API` on the Web.
 - 🔒 **Efficient Native Interop**: Employs FFI and JNI to create a fast, type-safe bridge between Dart and native code, ensuring robust and reliable communication.
 
 ## Platform Support
@@ -19,11 +19,13 @@ A high-performance Flutter plugin for cross-platform image format conversion and
 | iOS      | 14.0            | ImageIO, Core Graphics |
 | macOS    | 10.15           | ImageIO, Core Graphics |
 | Android  | 7               | BitmapFactory, Bitmap compression |
+| Windows  | 10              | Windows Imaging Component (WIC) |
 | Web      | -               | Canvas API |
 
 **Note:**
 - On iOS and macOS, WebP input is supported but WebP output is not supported.
 - On Android, HEIC input is supported on Android 9+ but HEIC output is not supported.
+- On Windows, JPEG and PNG output are always supported. HEIC output is supported where the OS ships the HEVC/HEIF codec (Windows 11 22H2+ out of the box; older Windows via the Microsoft Store "HEVC Video Extensions") — when the codec is absent, HEIC throws `UnsupportedError`. WebP output is not supported (Windows provides a WebP decoder but no encoder).
 - On Web, HEIC is not supported.
 
 ## Getting Started
@@ -60,6 +62,7 @@ final pngData = await ImageConverter.convert(
 ### Input Formats
 - **iOS/macOS**: JPEG, PNG, HEIC, WebP, BMP, GIF, TIFF, and more
 - **Android**: JPEG, PNG, WebP, GIF, BMP, HEIC (via BitmapFactory)
+- **Windows**: JPEG, PNG, GIF, BMP, TIFF, and (with the relevant OS codec) HEIC, WebP (via WIC)
 - **Web**: JPEG, PNG, WebP, GIF, BMP (via Canvas API)
 
 ### Output Formats
@@ -67,7 +70,7 @@ The supported output formats are defined by the `OutputFormat` enum, with platfo
 - **JPEG**: Supported on all platforms.
 - **PNG**: Supported on all platforms.
 - **WebP**: Supported on Android and Web.
-- **HEIC**: Supported on iOS/macOS only.
+- **HEIC**: Supported on iOS/macOS, and on Windows where the OS HEVC/HEIF codec is present.
 
 ## API Reference
 
@@ -140,6 +143,17 @@ The Android implementation uses [BitmapFactory](https://developer.android.com/re
 2. **Resizing**: `Bitmap.createScaledBitmap` is used to create a new, resized bitmap from the original, with filtering enabled for smoother results.
 3. **Compression**: `Bitmap.compress` encodes the final bitmap to the target format.
 4. **Buffer Management**: `ByteArrayOutputStream` manages output data.
+
+### Windows Implementation
+
+The Windows implementation uses the [Windows Imaging Component](https://learn.microsoft.com/en-us/windows/win32/wic/-wic-lib) (WIC), a COM-based imaging stack in `windowscodecs.dll`, bound directly via `dart:ffi` (no native build step):
+
+1. **Decoding**: `IWICImagingFactory::CreateDecoderFromStream` → `GetFrame` decodes the input.
+2. **Normalization**: `IWICFormatConverter` re-renders the frame to a fixed 32bpp BGRA surface, so output is independent of the source's pixel format (8/16-bit, grayscale, indexed, CMYK).
+3. **Resizing**: `IWICBitmapScaler` with high-quality cubic interpolation, when the target size differs.
+4. **Encoding**: `CreateEncoder` (by container GUID) → `IWICBitmapFrameEncode::WriteSource` encodes into an in-memory `IStream`. Quality for JPEG/HEIC is set via the encoder's `ImageQuality` property.
+
+**Note:** HEIC output requires the OS HEVC/HEIF codec. It ships with Windows 11 22H2+; on older Windows the encoder is absent and HEIC throws `UnsupportedError`. WebP output is not available (Windows provides a WebP decoder but no encoder). As with the other backends, every conversion renders through the fixed 8-bit surface even when no resize is requested.
 
 ### Web Implementation
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -365,7 +365,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.0"
+    version: "1.3.0"
   plugin_platform_interface:
     dependency: transitive
     description:

--- a/lib/platform_image_converter.dart
+++ b/lib/platform_image_converter.dart
@@ -10,6 +10,7 @@ import 'package:platform_image_converter/src/image_converter_platform_interface.
 import 'package:platform_image_converter/src/output_format.dart';
 import 'package:platform_image_converter/src/output_resize.dart';
 import 'package:platform_image_converter/src/web/shared.dart';
+import 'package:platform_image_converter/src/windows/shared.dart';
 
 export 'src/image_conversion_exception.dart';
 export 'src/output_format.dart';
@@ -18,7 +19,7 @@ export 'src/output_resize.dart';
 /// Main entry point for image format conversion.
 ///
 /// Provides a platform-agnostic interface to convert images across iOS,
-/// macOS, and Android platforms using native APIs.
+/// macOS, Android, Windows, and Web platforms using native APIs.
 class ImageConverter {
   /// The platform-specific implementation of the image converter.
   ///
@@ -43,6 +44,7 @@ class ImageConverter {
   /// **Returns:** A [Future] that completes with the converted image data.
   ///
   /// **Throws:**
+  /// - [ArgumentError]: If [quality] is outside the 1-100 range.
   /// - [UnsupportedError]: If the platform or output format is not supported.
   /// - [ImageDecodingException]: If the input image data cannot be decoded.
   /// - [ImageEncodingException]: If the image cannot be encoded to the target format.
@@ -72,10 +74,13 @@ class ImageConverter {
     ResizeMode resizeMode = const OriginalResizeMode(),
     bool runInIsolate = true,
   }) async {
-    assert(
-      quality >= 1 && quality <= 100,
-      'Quality must be between 1 and 100.',
-    );
+    if (quality < 1 || quality > 100) {
+      throw ArgumentError.value(
+        quality,
+        'quality',
+        'must be between 1 and 100',
+      );
+    }
     if (runInIsolate) {
       return await compute(_convertInIsolate, (
         inputData: inputData,
@@ -104,6 +109,7 @@ ImageConverterPlatform _getPlatformForTarget(TargetPlatform platform) {
   return switch (platform) {
     TargetPlatform.android => const ImageConverterAndroid(),
     TargetPlatform.iOS || TargetPlatform.macOS => const ImageConverterDarwin(),
+    TargetPlatform.windows => const ImageConverterWindows(),
     _ => throw UnsupportedError(
       'Image conversion is not supported on this platform: $platform',
     ),

--- a/lib/src/image_converter_platform_interface.dart
+++ b/lib/src/image_converter_platform_interface.dart
@@ -13,6 +13,7 @@ import 'package:platform_image_converter/src/output_resize.dart';
 /// **Implementations:**
 /// - ImageConverterDarwin: iOS and macOS using ImageIO
 /// - ImageConverterAndroid: Android using BitmapFactory
+/// - ImageConverterWindows: Windows using the Windows Imaging Component (WIC)
 /// - ImageConverterWeb: Web using Canvas API
 abstract interface class ImageConverterPlatform {
   /// Converts an image to a target format.

--- a/lib/src/output_format.dart
+++ b/lib/src/output_format.dart
@@ -3,18 +3,21 @@
 /// Specifies the target format when converting images.
 ///
 /// **Format Support:**
-/// | Format | iOS/macOS | Android | Web |
-/// |--------|-----------|---------| ----|
-/// | jpeg   | ✓         | ✓       | ✓   |
-/// | png    | ✓         | ✓       | ✓   |
-/// | webp   |           | ✓       | ✓   |
-/// | heic   | ✓         |         |     |
+/// | Format | iOS/macOS | Android | Windows | Web |
+/// |--------|-----------|---------|---------| ----|
+/// | jpeg   | ✓         | ✓       | ✓       | ✓   |
+/// | png    | ✓         | ✓       | ✓       | ✓   |
+/// | webp   |           | ✓       |         | ✓   |
+/// | heic   | ✓         |         | ✓†      |     |
+///
+/// † Windows HEIC output requires the OS HEVC/HEIF codec (Windows 11 22H2+, or
+///   the Store "HEVC Video Extensions"); otherwise it throws [UnsupportedError].
 ///
 /// **Notes:**
 /// - [jpeg]: Good compression with adjustable quality
 /// - [png]: Lossless compression, supports transparency
 /// - [webp]: Modern format with better compression than JPEG
-/// - [heic]: High Efficiency Image Format, not supported on Android
+/// - [heic]: High Efficiency Image Format, not supported on Android or Web
 enum OutputFormat {
   /// JPEG format (.jpg, .jpeg)
   /// Lossy compression, suitable for photos
@@ -25,10 +28,11 @@ enum OutputFormat {
   png,
 
   /// WebP format (.webp)
-  /// Modern format with superior compression (not supported on Darwin)
+  /// Modern format with superior compression (not supported on Darwin/Windows)
   webp,
 
   /// HEIC format (.heic)
-  /// High Efficiency Image Format (not supported on Android and Web)
+  /// High Efficiency Image Format. Output on Darwin and on Windows (where the
+  /// OS HEVC/HEIF codec is present); not supported on Android or Web.
   heic,
 }

--- a/lib/src/windows/native.dart
+++ b/lib/src/windows/native.dart
@@ -1,0 +1,303 @@
+import 'dart:ffi';
+import 'dart:typed_data';
+
+import 'package:ffi/ffi.dart';
+import 'package:platform_image_converter/src/image_conversion_exception.dart';
+import 'package:platform_image_converter/src/image_converter_platform_interface.dart';
+import 'package:platform_image_converter/src/output_format.dart';
+import 'package:platform_image_converter/src/output_resize.dart';
+import 'package:platform_image_converter/src/windows/wic.dart';
+
+extension on Pointer<Void> {
+  /// Registers this COM object to be released (`IUnknown::Release`) when [arena]
+  /// is released, mirroring the Darwin backend's `releasedBy` (CFRelease).
+  ///
+  /// The arena tears down when the enclosing `using` returns — which is *before*
+  /// the outer `CoUninitialize` — so every Release runs before COM is torn down,
+  /// without a manual cleanup list. Skips `nullptr`; the create call's own
+  /// null/HRESULT check surfaces the failure.
+  void releasedBy(Arena arena) {
+    if (this != nullptr) arena.onReleaseAll(() => comRelease(this));
+  }
+}
+
+/// Windows image converter built on the Windows Imaging Component (WIC), the
+/// modern COM imaging stack in `windowscodecs.dll`.
+///
+/// Mirrors the other backends' strategy: decode with the platform stack, always
+/// re-render through a fixed 8-bit-per-channel BGRA surface (normalizing
+/// 16-bit / grayscale / indexed / CMYK sources) and scale in the same pass,
+/// then encode.
+///
+/// **Pipeline:**
+/// - `IWICStream::InitializeFromMemory`: wrap the input bytes
+/// - `CreateDecoderFromStream` → `GetFrame`: decode
+/// - `IWICFormatConverter`: normalize to 32bpp BGRA
+/// - `IWICBitmapScaler` (high-quality cubic): resize when needed
+/// - `CreateEncoder` → `IWICBitmapFrameEncode::WriteSource`: encode into memory
+///
+/// **Output formats:**
+/// - JPEG and PNG: always available (built-in WIC codecs).
+/// - HEIC: available where the OS ships the HEVC/HEIF codec — Windows 11 22H2+
+///   out of the box, older Windows via the Store "HEVC Video Extensions". When
+///   the codec is missing or fails to initialize, `CreateEncoder` reports it and
+///   we throw [UnsupportedError] (graceful degradation rather than a hard crash).
+/// - WebP: not supported — Windows ships a WebP *decoder* but no encoder.
+final class ImageConverterWindows implements ImageConverterPlatform {
+  const ImageConverterWindows();
+
+  @override
+  Uint8List convert({
+    required Uint8List inputData,
+    OutputFormat format = OutputFormat.jpeg,
+    int quality = 100,
+    ResizeMode resizeMode = const OriginalResizeMode(),
+  }) {
+    // Reject unsupported output before any native side effect (CoInitialize)
+    if (format == .webp) {
+      throw UnsupportedError(
+        'WebP output is not supported on Windows: the OS provides a WebP '
+        'decoder but no encoder.',
+      );
+    }
+
+    // WIC is COM; initialize it on the calling thread (an isolate worker when
+    // run via `compute`), then balance it according to the HRESULT. `hresult`
+    // normalizes the signed Int32 so high-bit codes (rpcEChangedMode) compare.
+    final initHr = hresult(coInitializeEx(nullptr, coinitMultithreaded));
+    final mustUninitialize = switch (initHr) {
+      sOk || sFalse => true,
+      rpcEChangedMode => false,
+      _ => throw ImageConversionException(
+        'Failed to initialize COM (0x${initHr.toRadixString(16)}).',
+      ),
+    };
+
+    try {
+      return using((arena) {
+        final (lossy, container) = switch (format) {
+          .jpeg => (true, containerFormatJpeg(arena)),
+          .png => (false, containerFormatPng(arena)),
+          .heic => (true, containerFormatHeif(arena)),
+          .webp => throw StateError(
+            'unreachable: WebP is rejected before COM init',
+          ),
+        };
+
+        // InitializeFromMemory references (does not copy) the buffer, so it must
+        // outlive the decode — the arena keeps it alive for the whole call.
+        final inputPtr = arena<Uint8>(inputData.length);
+        inputPtr.asTypedList(inputData.length).setAll(0, inputData);
+
+        final factory = createImagingFactory(arena)..releasedBy(arena);
+        if (factory == nullptr) {
+          throw const ImageConversionException(
+            'Failed to create WIC imaging factory.',
+          );
+        }
+
+        // Create the encoder up front. A missing or unusable codec (notably
+        // HEVC/HEIF, which not every Windows ships) is reported by CreateEncoder,
+        // so checking it here — before any decode/normalize/resize — rejects an
+        // unsupported format without wasting work, matching the other backends
+        // which reject unsupported output before touching the image.
+        final pEncoder = arena<Pointer<Void>>();
+        final encoderHr = hresult(
+          wicCreateEncoder(factory, container, pEncoder),
+        );
+        if (encoderHr == wincodecErrComponentNotFound ||
+            encoderHr == wincodecErrComponentInitializeFailure) {
+          throw UnsupportedError(
+            '${format.name.toUpperCase()} encoding is unavailable on this '
+            'Windows: the required codec is not available. HEIC needs the '
+            'HEVC/HEIF codec (Windows 11 22H2+ ships it; older Windows can '
+            'install "HEVC Video Extensions" from the Microsoft Store).',
+          );
+        }
+        if (encoderHr != sOk) {
+          throw ImageEncodingException(
+            format,
+            'Failed to create ${format.name} encoder '
+            '(0x${encoderHr.toRadixString(16)}).',
+          );
+        }
+        final encoder = pEncoder.value..releasedBy(arena);
+
+        // Wrap the input bytes in an IWICStream.
+        final pStream = arena<Pointer<Void>>();
+        if (wicCreateStream(factory, pStream) != sOk) {
+          throw const ImageConversionException(
+            'Failed to create input stream.',
+          );
+        }
+        final inStream = pStream.value..releasedBy(arena);
+        if (wicStreamInitializeFromMemory(
+              inStream,
+              inputPtr,
+              inputData.length,
+            ) !=
+            sOk) {
+          throw const ImageConversionException(
+            'Failed to initialize input stream from image data.',
+          );
+        }
+
+        // Decode the first frame.
+        final pDecoder = arena<Pointer<Void>>();
+        if (wicCreateDecoderFromStream(factory, inStream, pDecoder) != sOk) {
+          throw const ImageDecodingException('Invalid image data.');
+        }
+        final decoder = pDecoder.value..releasedBy(arena);
+        final pFrame = arena<Pointer<Void>>();
+        if (wicDecoderGetFrame(decoder, 0, pFrame) != sOk) {
+          throw const ImageDecodingException();
+        }
+        final frame = pFrame.value..releasedBy(arena);
+
+        final widthPtr = arena<Uint32>();
+        final heightPtr = arena<Uint32>();
+        if (wicGetSize(frame, widthPtr, heightPtr) != sOk) {
+          throw const ImageDecodingException('Failed to read image size.');
+        }
+        final (newWidth, newHeight) = resizeMode.calculateSize(
+          widthPtr.value,
+          heightPtr.value,
+        );
+
+        // Normalize to a fixed 32bpp premultiplied-BGRA surface: output no
+        // longer depends on the source pixel format, and alpha is interpolated
+        // in the correct (premultiplied) space when scaling. Premultiplied
+        // transparent pixels carry RGB 0, so flattening to a no-alpha format
+        // (JPEG) drops to black instead of leaking the source's stored RGB.
+        // The flatten color is backend-defined and not guaranteed identical
+        // across platforms. The PNG/HEIC encoders restore straight alpha.
+        final pConverter = arena<Pointer<Void>>();
+        if (wicCreateFormatConverter(factory, pConverter) != sOk) {
+          throw const ImageConversionException(
+            'Failed to create pixel-format converter.',
+          );
+        }
+        final converter = pConverter.value..releasedBy(arena);
+        if (wicConverterInitialize(
+              converter,
+              frame,
+              pixelFormat32bppPBGRA(arena),
+            ) !=
+            sOk) {
+          throw const ImageConversionException(
+            'Failed to normalize source pixel format.',
+          );
+        }
+
+        // Scale only when the target size differs (high-quality cubic).
+        var source = converter;
+        if (newWidth != widthPtr.value || newHeight != heightPtr.value) {
+          final pScaler = arena<Pointer<Void>>();
+          if (wicCreateBitmapScaler(factory, pScaler) != sOk) {
+            throw const ImageConversionException(
+              'Failed to create bitmap scaler.',
+            );
+          }
+          final scaler = pScaler.value..releasedBy(arena);
+          if (wicScalerInitialize(scaler, converter, newWidth, newHeight) !=
+              sOk) {
+            throw const ImageConversionException('Failed to resize image.');
+          }
+          source = scaler;
+        }
+
+        // Growable in-memory output stream.
+        final pOut = arena<Pointer<Void>>();
+        if (createStreamOnHGlobal(nullptr, fDeleteOnRelease, pOut) != sOk ||
+            pOut.value == nullptr) {
+          throw const ImageConversionException(
+            'Failed to create output stream.',
+          );
+        }
+        final outStream = pOut.value..releasedBy(arena);
+        if (wicEncoderInitialize(encoder, outStream) != sOk) {
+          throw ImageEncodingException(format, 'Failed to initialize encoder.');
+        }
+
+        // Create the frame and (for lossy formats) set the quality.
+        final pFrameEncode = arena<Pointer<Void>>();
+        final pPropertyBag = arena<Pointer<Void>>();
+        if (wicEncoderCreateNewFrame(encoder, pFrameEncode, pPropertyBag) !=
+            sOk) {
+          throw ImageEncodingException(format, 'Failed to create frame.');
+        }
+        final frameEncode = pFrameEncode.value..releasedBy(arena);
+        final propertyBag = pPropertyBag.value..releasedBy(arena);
+
+        if (lossy) {
+          // quality is validated 1..100 by the public API; WIC wants 0..1.
+          if (propertyBag == nullptr) {
+            throw ImageEncodingException(
+              format,
+              'Encoder did not provide an options bag to set quality.',
+            );
+          }
+          if (writeImageQuality(arena, propertyBag, quality / 100.0) != sOk) {
+            throw ImageEncodingException(
+              format,
+              'Failed to set ${format.name} encoder quality.',
+            );
+          }
+        }
+        if (wicFrameInitialize(frameEncode, propertyBag) != sOk) {
+          throw ImageEncodingException(format, 'Failed to initialize frame.');
+        }
+        if (wicFrameSetSize(frameEncode, newWidth, newHeight) != sOk) {
+          throw ImageEncodingException(format, 'Failed to set output size.');
+        }
+        if (wicFrameWriteSource(frameEncode, source) != sOk) {
+          throw ImageEncodingException(
+            format,
+            'Failed to encode image to ${format.name}.',
+          );
+        }
+        if (wicFrameCommit(frameEncode) != sOk ||
+            wicEncoderCommit(encoder) != sOk) {
+          throw ImageEncodingException(
+            format,
+            'Failed to finalize ${format.name} output.',
+          );
+        }
+
+        return _readStreamBytes(arena, outStream, format);
+      });
+    } finally {
+      if (mustUninitialize) coUninitialize();
+    }
+  }
+
+  /// Reads every byte written to [stream] back into a Dart [Uint8List]. The
+  /// exact length comes from seeking to the end (the backing `HGLOBAL` is
+  /// rounded up, so its allocated size cannot be trusted).
+  Uint8List _readStreamBytes(
+    Arena arena,
+    Pointer<Void> stream,
+    OutputFormat format,
+  ) {
+    final sizePtr = arena<Uint64>();
+    if (comSeek(stream, 0, streamSeekEnd, sizePtr) != sOk) {
+      throw ImageEncodingException(format, 'Failed to size encoded output.');
+    }
+    final length = sizePtr.value;
+
+    final hGlobalPtr = arena<Pointer<Void>>();
+    if (getHGlobalFromStream(stream, hGlobalPtr) != sOk) {
+      throw ImageEncodingException(format, 'Failed to read encoded output.');
+    }
+
+    final dataPtr = globalLock(hGlobalPtr.value);
+    if (dataPtr == nullptr) {
+      throw ImageEncodingException(format, 'Failed to lock encoded output.');
+    }
+    try {
+      return Uint8List.fromList(dataPtr.asTypedList(length));
+    } finally {
+      globalUnlock(hGlobalPtr.value);
+    }
+  }
+}

--- a/lib/src/windows/shared.dart
+++ b/lib/src/windows/shared.dart
@@ -1,0 +1,3 @@
+export 'stub.dart'
+    if (dart.library.io) 'native.dart'
+    if (dart.library.js_interop) 'stub.dart';

--- a/lib/src/windows/stub.dart
+++ b/lib/src/windows/stub.dart
@@ -1,0 +1,17 @@
+import 'dart:typed_data';
+
+import 'package:platform_image_converter/src/image_converter_platform_interface.dart';
+import 'package:platform_image_converter/src/output_format.dart';
+import 'package:platform_image_converter/src/output_resize.dart';
+
+final class ImageConverterWindows implements ImageConverterPlatform {
+  const ImageConverterWindows();
+
+  @override
+  Uint8List convert({
+    required Uint8List inputData,
+    OutputFormat format = OutputFormat.jpeg,
+    int quality = 100,
+    ResizeMode resizeMode = const OriginalResizeMode(),
+  }) => throw UnimplementedError();
+}

--- a/lib/src/windows/wic.dart
+++ b/lib/src/windows/wic.dart
@@ -1,0 +1,596 @@
+// Field/parameter names deliberately mirror the Win32 / WIC C names.
+// ignore_for_file: non_constant_identifier_names
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+
+/// Hand-written FFI bindings for the Windows Imaging Component (WIC) — the
+/// modern, COM-based imaging stack (`windowscodecs.dll`) that decodes, scales
+/// and encodes images, including HEIC where the OS ships the HEVC/HEIF codec
+/// (Windows 11 22H2+ out of the box; older Windows via the Store extension).
+///
+/// These are written by hand by necessity, not convenience. No code generator
+/// emits this surface:
+///   * ffigen parses C only; WIC is pure COM (vtable dispatch), which ffigen
+///     cannot model.
+///   * The `win32` package (generated from win32metadata) does not include the
+///     WIC interfaces at all (verified against 6.3.0).
+/// So every call below is dispatched by reading the function pointer at a fixed
+/// vtable slot of the COM object (its first field is the pointer to its vtable).
+/// The slot indices are taken verbatim from the SDK's `wincodec.h` `*Vtbl`
+/// structs — they are part of the COM ABI and never change for a shipped
+/// interface.
+///
+/// All symbols are resolved lazily, so the `DynamicLibrary.open` calls only run
+/// on Windows (the converter is only instantiated for `TargetPlatform.windows`).
+
+// ---------------------------------------------------------------------------
+// System libraries (COM + memory helpers)
+// ---------------------------------------------------------------------------
+
+final DynamicLibrary _ole32 = DynamicLibrary.open('ole32.dll');
+final DynamicLibrary _kernel32 = DynamicLibrary.open('kernel32.dll');
+
+/// `S_OK`.
+const int sOk = 0;
+
+/// `S_FALSE` — a success HRESULT (`SUCCEEDED(S_FALSE)` is true). From
+/// `CoInitializeEx` it means COM was already initialized on this thread with the
+/// same apartment: the call still took a reference that must be balanced with
+/// `CoUninitialize`.
+const int sFalse = 1;
+
+/// `WINCODEC_ERR_COMPONENTNOTFOUND` — returned by `CreateEncoder` when no codec
+/// for the requested container is installed (e.g. HEIF without the HEVC codec).
+const int wincodecErrComponentNotFound = 0x88982F50;
+
+/// `WINCODEC_ERR_COMPONENTINITIALIZEFAILURE` — `CreateEncoder` found the codec's
+/// registration but it failed to initialize. For HEIF this is what Windows
+/// returns when the container handler is registered yet the underlying HEVC
+/// codec is missing (seen on GitHub-hosted runners and any machine without the
+/// Microsoft Store "HEVC Video Extensions"). The codec is unusable here, same
+/// as [wincodecErrComponentNotFound].
+const int wincodecErrComponentInitializeFailure = 0x88982F8B;
+
+/// `COINIT_MULTITHREADED` (0) — the apartment requested from `CoInitializeEx`.
+/// WIC's in-proc codecs are used synchronously on a single thread, so MTA is
+/// sufficient (and is COM's default concurrency model).
+const int coinitMultithreaded = 0;
+
+/// `RPC_E_CHANGED_MODE` — `CoInitializeEx` when COM is already up on this thread
+/// with a different apartment. COM is usable; we just must not balance-uninit.
+const int rpcEChangedMode = 0x80010106;
+
+/// `STREAM_SEEK_END` for `IStream::Seek`.
+const int streamSeekEnd = 2;
+
+/// `fDeleteOnRelease = TRUE` for `CreateStreamOnHGlobal` — the stream owns its
+/// backing `HGLOBAL` and frees it when released.
+const int fDeleteOnRelease = 1;
+
+/// `CLSCTX_INPROC_SERVER`.
+const int _clsctxInprocServer = 1;
+
+// CoInitializeEx(NULL, COINIT_MULTITHREADED) / CoUninitialize.
+final int Function(Pointer<Void>, int) coInitializeEx = _ole32
+    .lookupFunction<
+      Int32 Function(Pointer<Void>, Uint32),
+      int Function(Pointer<Void>, int)
+    >('CoInitializeEx');
+final void Function() coUninitialize = _ole32
+    .lookupFunction<Void Function(), void Function()>('CoUninitialize');
+
+final int Function(
+  Pointer<Uint8> rclsid,
+  Pointer<Void> pUnkOuter,
+  int dwClsContext,
+  Pointer<Uint8> riid,
+  Pointer<Pointer<Void>> ppv,
+)
+coCreateInstance = _ole32
+    .lookupFunction<
+      Int32 Function(
+        Pointer<Uint8>,
+        Pointer<Void>,
+        Uint32,
+        Pointer<Uint8>,
+        Pointer<Pointer<Void>>,
+      ),
+      int Function(
+        Pointer<Uint8>,
+        Pointer<Void>,
+        int,
+        Pointer<Uint8>,
+        Pointer<Pointer<Void>>,
+      )
+    >('CoCreateInstance');
+
+/// `CreateStreamOnHGlobal(NULL, TRUE, &stream)` — a growable in-memory output
+/// `IStream` whose backing `HGLOBAL` is freed when the stream is released.
+final int Function(Pointer<Void>, int, Pointer<Pointer<Void>>)
+createStreamOnHGlobal = _ole32
+    .lookupFunction<
+      Int32 Function(Pointer<Void>, Int32, Pointer<Pointer<Void>>),
+      int Function(Pointer<Void>, int, Pointer<Pointer<Void>>)
+    >('CreateStreamOnHGlobal');
+
+/// `GetHGlobalFromStream` — recovers the `HGLOBAL` backing the output stream.
+final int Function(Pointer<Void>, Pointer<Pointer<Void>>) getHGlobalFromStream =
+    _ole32.lookupFunction<
+      Int32 Function(Pointer<Void>, Pointer<Pointer<Void>>),
+      int Function(Pointer<Void>, Pointer<Pointer<Void>>)
+    >('GetHGlobalFromStream');
+
+final Pointer<Uint8> Function(Pointer<Void>) globalLock = _kernel32
+    .lookupFunction<
+      Pointer<Uint8> Function(Pointer<Void>),
+      Pointer<Uint8> Function(Pointer<Void>)
+    >('GlobalLock');
+final int Function(Pointer<Void>) globalUnlock = _kernel32
+    .lookupFunction<Int32 Function(Pointer<Void>), int Function(Pointer<Void>)>(
+      'GlobalUnlock',
+    );
+
+// ---------------------------------------------------------------------------
+// GUIDs
+// ---------------------------------------------------------------------------
+
+/// Allocates a 16-byte Windows `GUID`/`CLSID` in [arena] from its canonical
+/// components (`Data1` LE u32, `Data2`/`Data3` LE u16, `Data4` 8 raw bytes).
+Pointer<Uint8> guid(Arena arena, int d1, int d2, int d3, List<int> d4) {
+  final p = arena<Uint8>(16);
+  p[0] = d1 & 0xff;
+  p[1] = (d1 >> 8) & 0xff;
+  p[2] = (d1 >> 16) & 0xff;
+  p[3] = (d1 >> 24) & 0xff;
+  p[4] = d2 & 0xff;
+  p[5] = (d2 >> 8) & 0xff;
+  p[6] = d3 & 0xff;
+  p[7] = (d3 >> 8) & 0xff;
+  for (var i = 0; i < 8; i++) {
+    p[8 + i] = d4[i];
+  }
+  return p;
+}
+
+Pointer<Uint8> clsidWicImagingFactory(Arena a) => guid(
+  a,
+  0xCACAF262,
+  0x9370,
+  0x4615,
+  const [0xA1, 0x3B, 0x9F, 0x55, 0x39, 0xDA, 0x4C, 0x0A],
+);
+Pointer<Uint8> iidWicImagingFactory(Arena a) => guid(
+  a,
+  0xEC5EC8A9,
+  0xC395,
+  0x4314,
+  const [0x9C, 0x77, 0x54, 0xD7, 0xA9, 0x35, 0xFF, 0x70],
+);
+
+Pointer<Uint8> containerFormatJpeg(Arena a) => guid(
+  a,
+  0x19E4A5AA,
+  0x5662,
+  0x4FC5,
+  const [0xA0, 0xC0, 0x17, 0x58, 0x02, 0x8E, 0x10, 0x57],
+);
+Pointer<Uint8> containerFormatPng(Arena a) => guid(
+  a,
+  0x1B7CFAF4,
+  0x713F,
+  0x473C,
+  const [0xBB, 0xCD, 0x61, 0x37, 0x42, 0x5F, 0xAE, 0xAF],
+);
+Pointer<Uint8> containerFormatHeif(Arena a) => guid(
+  a,
+  0xE1E62521,
+  0x6787,
+  0x405B,
+  const [0xA3, 0x39, 0x50, 0x07, 0x15, 0xB5, 0x76, 0x3F],
+);
+
+/// `GUID_WICPixelFormat32bppPBGRA` — 8-bit premultiplied alpha; the fixed
+/// surface every source is normalized into. Premultiplied alpha is the correct
+/// space to interpolate in when scaling, and makes fully-transparent pixels
+/// carry RGB 0 so flattening to a no-alpha format (JPEG) drops to black rather
+/// than leaking the source's stored RGB. The flatten color is backend-defined
+/// and not guaranteed identical across platforms.
+Pointer<Uint8> pixelFormat32bppPBGRA(Arena a) => guid(
+  a,
+  0x6FDDC324,
+  0x4E03,
+  0x4BFE,
+  const [0xB1, 0x85, 0x3D, 0x77, 0x76, 0x8D, 0xC9, 0x10],
+);
+
+// ---------------------------------------------------------------------------
+// Enum values (from wincodec.h)
+// ---------------------------------------------------------------------------
+
+const int wicDecodeMetadataCacheOnDemand = 0;
+const int wicBitmapDitherTypeNone = 0;
+const int wicBitmapPaletteTypeCustom = 0;
+const int wicBitmapInterpolationModeHighQualityCubic = 4;
+const int wicBitmapEncoderNoCache = 2;
+
+// ---------------------------------------------------------------------------
+// COM vtable dispatch
+//
+// Each wrapper reads the function pointer at the method's fixed vtable slot and
+// invokes it. `asFunction` requires statically-known native/Dart signatures, so
+// each call spells out its own concrete types.
+// ---------------------------------------------------------------------------
+
+/// Treats a signed `Int32` HRESULT as its unsigned 32-bit value, so it can be
+/// compared against high-bit-set codes like [wincodecErrComponentNotFound].
+int hresult(int raw) => raw & 0xFFFFFFFF;
+
+/// Address of the function pointer at vtable [index] of COM object [obj]. Each
+/// slot is one pointer wide (`sizeOf<IntPtr>()` — 8 on the 64-bit-only Windows
+/// targets Flutter supports).
+int _slot(Pointer<Void> obj, int index) => Pointer<IntPtr>.fromAddress(
+  obj.cast<IntPtr>().value + index * sizeOf<IntPtr>(),
+).value;
+
+/// `IUnknown::Release` (vtable slot 2), on every WIC/COM object.
+int comRelease(Pointer<Void> obj) =>
+    Pointer<NativeFunction<Uint32 Function(Pointer<Void>)>>.fromAddress(
+      _slot(obj, 2),
+    ).asFunction<int Function(Pointer<Void>)>()(obj);
+
+/// `IStream::Seek` (slot 5) — used with [streamSeekEnd] to size the output.
+int comSeek(Pointer<Void> obj, int move, int origin, Pointer<Uint64> newPos) =>
+    Pointer<
+          NativeFunction<
+            Int32 Function(Pointer<Void>, Int64, Uint32, Pointer<Uint64>)
+          >
+        >.fromAddress(_slot(obj, 5))
+        .asFunction<int Function(Pointer<Void>, int, int, Pointer<Uint64>)>()(
+      obj,
+      move,
+      origin,
+      newPos,
+    );
+
+// ---- IWICImagingFactory ----
+
+/// `CreateStream` (slot 14) → an empty `IWICStream`.
+int wicCreateStream(Pointer<Void> factory, Pointer<Pointer<Void>> out) =>
+    Pointer<
+          NativeFunction<Int32 Function(Pointer<Void>, Pointer<Pointer<Void>>)>
+        >.fromAddress(_slot(factory, 14))
+        .asFunction<int Function(Pointer<Void>, Pointer<Pointer<Void>>)>()(
+      factory,
+      out,
+    );
+
+/// `CreateDecoderFromStream` (slot 4). `pguidVendor` and options are null/0.
+int wicCreateDecoderFromStream(
+  Pointer<Void> factory,
+  Pointer<Void> stream,
+  Pointer<Pointer<Void>> out,
+) =>
+    Pointer<
+          NativeFunction<
+            Int32 Function(
+              Pointer<Void>,
+              Pointer<Void>,
+              Pointer<Void>,
+              Uint32,
+              Pointer<Pointer<Void>>,
+            )
+          >
+        >.fromAddress(_slot(factory, 4))
+        .asFunction<
+          int Function(
+            Pointer<Void>,
+            Pointer<Void>,
+            Pointer<Void>,
+            int,
+            Pointer<Pointer<Void>>,
+          )
+        >()(factory, stream, nullptr, wicDecodeMetadataCacheOnDemand, out);
+
+/// `CreateFormatConverter` (slot 10).
+int wicCreateFormatConverter(
+  Pointer<Void> factory,
+  Pointer<Pointer<Void>> out,
+) =>
+    Pointer<
+          NativeFunction<Int32 Function(Pointer<Void>, Pointer<Pointer<Void>>)>
+        >.fromAddress(_slot(factory, 10))
+        .asFunction<int Function(Pointer<Void>, Pointer<Pointer<Void>>)>()(
+      factory,
+      out,
+    );
+
+/// `CreateBitmapScaler` (slot 11).
+int wicCreateBitmapScaler(Pointer<Void> factory, Pointer<Pointer<Void>> out) =>
+    Pointer<
+          NativeFunction<Int32 Function(Pointer<Void>, Pointer<Pointer<Void>>)>
+        >.fromAddress(_slot(factory, 11))
+        .asFunction<int Function(Pointer<Void>, Pointer<Pointer<Void>>)>()(
+      factory,
+      out,
+    );
+
+/// `CreateEncoder` (slot 8). Reports a missing or unusable codec for
+/// [containerGuid] via [wincodecErrComponentNotFound] (not registered) or
+/// [wincodecErrComponentInitializeFailure] (registered but fails to initialize).
+int wicCreateEncoder(
+  Pointer<Void> factory,
+  Pointer<Uint8> containerGuid,
+  Pointer<Pointer<Void>> out,
+) =>
+    Pointer<
+          NativeFunction<
+            Int32 Function(
+              Pointer<Void>,
+              Pointer<Uint8>,
+              Pointer<Void>,
+              Pointer<Pointer<Void>>,
+            )
+          >
+        >.fromAddress(_slot(factory, 8))
+        .asFunction<
+          int Function(
+            Pointer<Void>,
+            Pointer<Uint8>,
+            Pointer<Void>,
+            Pointer<Pointer<Void>>,
+          )
+        >()(factory, containerGuid, nullptr, out);
+
+// ---- IWICStream ----
+
+/// `InitializeFromMemory` (slot 16). Does NOT copy — [buffer] must outlive use.
+int wicStreamInitializeFromMemory(
+  Pointer<Void> stream,
+  Pointer<Uint8> buffer,
+  int size,
+) =>
+    Pointer<
+          NativeFunction<Int32 Function(Pointer<Void>, Pointer<Uint8>, Uint32)>
+        >.fromAddress(_slot(stream, 16))
+        .asFunction<int Function(Pointer<Void>, Pointer<Uint8>, int)>()(
+      stream,
+      buffer,
+      size,
+    );
+
+// ---- IWICBitmapDecoder ----
+
+/// `GetFrame` (slot 13).
+int wicDecoderGetFrame(
+  Pointer<Void> decoder,
+  int index,
+  Pointer<Pointer<Void>> out,
+) =>
+    Pointer<
+          NativeFunction<
+            Int32 Function(Pointer<Void>, Uint32, Pointer<Pointer<Void>>)
+          >
+        >.fromAddress(_slot(decoder, 13))
+        .asFunction<int Function(Pointer<Void>, int, Pointer<Pointer<Void>>)>()(
+      decoder,
+      index,
+      out,
+    );
+
+// ---- IWICBitmapSource (frame / converter / scaler) ----
+
+/// `GetSize` (slot 3).
+int wicGetSize(Pointer<Void> src, Pointer<Uint32> w, Pointer<Uint32> h) =>
+    Pointer<
+          NativeFunction<
+            Int32 Function(Pointer<Void>, Pointer<Uint32>, Pointer<Uint32>)
+          >
+        >.fromAddress(_slot(src, 3))
+        .asFunction<
+          int Function(Pointer<Void>, Pointer<Uint32>, Pointer<Uint32>)
+        >()(src, w, h);
+
+// ---- IWICFormatConverter ----
+
+/// `Initialize` (slot 8): convert [source] into [dstFormat] (no dither/palette).
+int wicConverterInitialize(
+  Pointer<Void> converter,
+  Pointer<Void> source,
+  Pointer<Uint8> dstFormat,
+) =>
+    Pointer<
+          NativeFunction<
+            Int32 Function(
+              Pointer<Void>,
+              Pointer<Void>,
+              Pointer<Uint8>,
+              Int32,
+              Pointer<Void>,
+              Double,
+              Int32,
+            )
+          >
+        >.fromAddress(_slot(converter, 8))
+        .asFunction<
+          int Function(
+            Pointer<Void>,
+            Pointer<Void>,
+            Pointer<Uint8>,
+            int,
+            Pointer<Void>,
+            double,
+            int,
+          )
+        >()(
+      converter,
+      source,
+      dstFormat,
+      wicBitmapDitherTypeNone,
+      nullptr,
+      0.0,
+      wicBitmapPaletteTypeCustom,
+    );
+
+// ---- IWICBitmapScaler ----
+
+/// `Initialize` (slot 8): scale [source] to [w]x[h] with high-quality cubic.
+int wicScalerInitialize(
+  Pointer<Void> scaler,
+  Pointer<Void> source,
+  int w,
+  int h,
+) =>
+    Pointer<
+          NativeFunction<
+            Int32 Function(Pointer<Void>, Pointer<Void>, Uint32, Uint32, Int32)
+          >
+        >.fromAddress(_slot(scaler, 8))
+        .asFunction<
+          int Function(Pointer<Void>, Pointer<Void>, int, int, int)
+        >()(scaler, source, w, h, wicBitmapInterpolationModeHighQualityCubic);
+
+// ---- IWICBitmapEncoder ----
+
+/// `Initialize` (slot 3): bind the encoder to an output [stream].
+int wicEncoderInitialize(Pointer<Void> encoder, Pointer<Void> stream) =>
+    Pointer<
+          NativeFunction<Int32 Function(Pointer<Void>, Pointer<Void>, Int32)>
+        >.fromAddress(_slot(encoder, 3))
+        .asFunction<int Function(Pointer<Void>, Pointer<Void>, int)>()(
+      encoder,
+      stream,
+      wicBitmapEncoderNoCache,
+    );
+
+/// `CreateNewFrame` (slot 10). Out-params: the frame encode and its property
+/// bag (the latter receives encoder options like JPEG/HEIF `ImageQuality`).
+int wicEncoderCreateNewFrame(
+  Pointer<Void> encoder,
+  Pointer<Pointer<Void>> frame,
+  Pointer<Pointer<Void>> propertyBag,
+) =>
+    Pointer<
+          NativeFunction<
+            Int32 Function(
+              Pointer<Void>,
+              Pointer<Pointer<Void>>,
+              Pointer<Pointer<Void>>,
+            )
+          >
+        >.fromAddress(_slot(encoder, 10))
+        .asFunction<
+          int Function(
+            Pointer<Void>,
+            Pointer<Pointer<Void>>,
+            Pointer<Pointer<Void>>,
+          )
+        >()(encoder, frame, propertyBag);
+
+/// `Commit` (slot 11).
+int wicEncoderCommit(Pointer<Void> encoder) =>
+    Pointer<NativeFunction<Int32 Function(Pointer<Void>)>>.fromAddress(
+      _slot(encoder, 11),
+    ).asFunction<int Function(Pointer<Void>)>()(encoder);
+
+// ---- IWICBitmapFrameEncode ----
+
+/// `Initialize` (slot 3) with the (optional) configured property bag.
+int wicFrameInitialize(Pointer<Void> frame, Pointer<Void> propertyBag) =>
+    Pointer<
+          NativeFunction<Int32 Function(Pointer<Void>, Pointer<Void>)>
+        >.fromAddress(_slot(frame, 3))
+        .asFunction<int Function(Pointer<Void>, Pointer<Void>)>()(
+      frame,
+      propertyBag,
+    );
+
+/// `SetSize` (slot 4).
+int wicFrameSetSize(Pointer<Void> frame, int w, int h) =>
+    Pointer<
+          NativeFunction<Int32 Function(Pointer<Void>, Uint32, Uint32)>
+        >.fromAddress(_slot(frame, 4))
+        .asFunction<int Function(Pointer<Void>, int, int)>()(frame, w, h);
+
+/// `WriteSource` (slot 11): draw [source] into the frame (full rect → null).
+int wicFrameWriteSource(Pointer<Void> frame, Pointer<Void> source) =>
+    Pointer<
+          NativeFunction<
+            Int32 Function(Pointer<Void>, Pointer<Void>, Pointer<Void>)
+          >
+        >.fromAddress(_slot(frame, 11))
+        .asFunction<
+          int Function(Pointer<Void>, Pointer<Void>, Pointer<Void>)
+        >()(frame, source, nullptr);
+
+/// `Commit` (slot 12).
+int wicFrameCommit(Pointer<Void> frame) =>
+    Pointer<NativeFunction<Int32 Function(Pointer<Void>)>>.fromAddress(
+      _slot(frame, 12),
+    ).asFunction<int Function(Pointer<Void>)>()(frame);
+
+// ---- IPropertyBag2 ----
+
+/// `Write` (slot 4): set [count] properties described by [propBag2]/[variant].
+int propertyBagWrite(
+  Pointer<Void> bag,
+  int count,
+  Pointer<Uint8> propBag2,
+  Pointer<Uint8> variant,
+) =>
+    Pointer<
+          NativeFunction<
+            Int32 Function(
+              Pointer<Void>,
+              Uint32,
+              Pointer<Uint8>,
+              Pointer<Uint8>,
+            )
+          >
+        >.fromAddress(_slot(bag, 4))
+        .asFunction<
+          int Function(Pointer<Void>, int, Pointer<Uint8>, Pointer<Uint8>)
+        >()(bag, count, propBag2, variant);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Creates the `IWICImagingFactory`. Returns null on failure (caller throws).
+Pointer<Void> createImagingFactory(Arena arena) {
+  final pp = arena<Pointer<Void>>();
+  final hr = coCreateInstance(
+    clsidWicImagingFactory(arena),
+    nullptr,
+    _clsctxInprocServer,
+    iidWicImagingFactory(arena),
+    pp,
+  );
+  return hr == sOk ? pp.value : nullptr;
+}
+
+/// Writes a single `ImageQuality` float (0..1) into [bag] via a `PROPBAG2` +
+/// `VARIANT` pair allocated in [arena]. Used for JPEG and HEIF (lossy) encoders.
+int writeImageQuality(Arena arena, Pointer<Void> bag, double quality) {
+  // VT_R4 == 4 (32-bit float), PROPBAG2_TYPE_DATA == 1.
+  const vtR4 = 4;
+  const propbag2TypeData = 1;
+
+  // PROPBAG2 (64-bit layout, 40 bytes — identical on x64 and arm64 Windows):
+  // dwType@0, vt@4, cfType@6, dwHint@8, pstrName@16, clsid@24. Zero it, then
+  // set the fields the encoder reads.
+  final pb = arena<Uint8>(40);
+  pb.asTypedList(40).fillRange(0, 40, 0);
+  pb.cast<Uint32>().value = propbag2TypeData; // dwType
+  (pb + 4).cast<Uint16>().value = vtR4; // vt
+  final name = 'ImageQuality'.toNativeUtf16(allocator: arena);
+  (pb + 16).cast<IntPtr>().value = name.address; // pstrName
+
+  // VARIANT (64-bit, 24 bytes): vt@0, fltVal@8.
+  final v = arena<Uint8>(24);
+  v.asTypedList(24).fillRange(0, 24, 0);
+  v.cast<Uint16>().value = vtR4; // vt
+  (v + 8).cast<Float>().value = quality;
+
+  return propertyBagWrite(bag, 1, pb, v);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: platform_image_converter
 description: "A high-performance Flutter plugin for cross-platform image format conversion using native APIs."
-version: 1.2.1
+version: 1.3.0
 homepage: https://github.com/koji-1009/platform_image_converter
 topics:
   - image
@@ -9,6 +9,7 @@ platforms:
   ios:
   macos:
   web:
+  windows:
 
 environment:
   sdk: ^3.10.0
@@ -22,7 +23,8 @@ dependencies:
   web: ^1.0.0
   
 dev_dependencies:
-  test: ^1.28.0
+  flutter_test:
+    sdk: flutter
   flutter_lints: ^6.0.0
   jnigen: ^0.16.0
   ffigen: ^20.1.1

--- a/test/output_resize_test.dart
+++ b/test/output_resize_test.dart
@@ -1,5 +1,5 @@
+import 'package:flutter_test/flutter_test.dart';
 import 'package:platform_image_converter/src/output_resize.dart';
-import 'package:test/test.dart';
 
 void main() {
   group('ResizeMode', () {

--- a/test/quality_validation_test.dart
+++ b/test/quality_validation_test.dart
@@ -1,0 +1,23 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_image_converter/platform_image_converter.dart';
+
+void main() {
+  // A plain unit test for the quality guard — no widgets, no binding. It needs
+  // `flutter test` rather than `dart test` only because ImageConverter imports
+  // package:flutter. Quality is validated before any decoding or platform call,
+  // so a single dummy byte exercises the guard.
+  final dummy = Uint8List.fromList(const [0]);
+
+  test('quality outside 1-100 throws ArgumentError', () async {
+    await expectLater(
+      ImageConverter.convert(inputData: dummy, quality: 0),
+      throwsArgumentError,
+    );
+    await expectLater(
+      ImageConverter.convert(inputData: dummy, quality: 101),
+      throwsArgumentError,
+    );
+  });
+}


### PR DESCRIPTION
Fixes https://github.com/koji-1009/platform_image_converter/issues/16

## Summary

Adds the Windows backend for `platform_image_converter`, built on the **Windows Imaging Component (WIC)** — the modern COM-based imaging stack in `windowscodecs.dll` — bound directly with `dart:ffi`. There is no native build step and no bundled binaries: the plugin just calls system DLLs, consistent with the package's pure-FFI design.

## Output format support (Windows)

| Format | Supported | Notes |
|--------|:---------:|-------|
| JPEG / PNG | ✅ always | built-in WIC codecs |
| HEIC | ✅ codec-dependent | requires the OS HEVC/HEIF codec — shipped with Windows 11 22H2+, or installable from the Microsoft Store ("HEVC Video Extensions"). When the codec is missing **or fails to initialize**, `CreateEncoder` reports it and we throw `UnsupportedError` (graceful degradation, not a crash). |
| WebP | ❌ | Windows ships a WebP *decoder* but no encoder, so WebP output is rejected with `UnsupportedError` before COM is even initialized. |

This matches the package's per-platform-native philosophy: WebP output is likewise unsupported on Darwin, and HEIC output is likewise unsupported on Android/Web.

## Pipeline

Decode → normalize to a fixed **premultiplied 32bpp BGRA** surface → high-quality cubic resize (only when the target size differs) → encode into an in-memory stream. Normalizing always (even without a resize) makes output independent of the source's pixel format, matching the Android/Darwin/Web backends.

Premultiplied alpha is deliberate: it is the correct space in which to interpolate alpha when scaling, and it makes fully-transparent pixels carry RGB 0, so flattening to a no-alpha format (JPEG) drops to **black** instead of leaking the source's stored RGB. The exact flatten colour is backend-defined and **not guaranteed identical across platforms** (Darwin's ImageIO, for example, flattens transparent areas toward white). The PNG/HEIC encoders restore straight alpha on write, so transparency-preserving output is unaffected.

## Implementation notes

- **Hand-written COM bindings by necessity.** No code generator emits this surface: `ffigen` parses C only (WIC is COM/vtable dispatch), and the `win32` package does not include the WIC interfaces. The vtable slot indices are taken verbatim from the SDK's `wincodec.h` `*Vtbl` structs and are frozen by the COM ABI.
- **COM lifetimes** are managed with a `releasedBy(arena)` extension mirroring the Darwin backend's `CFRelease` pattern: each object self-registers `IUnknown::Release` on arena teardown, which runs before `CoUninitialize` — no manual cleanup list, exception-safe by construction. `CoInitializeEx`/`CoUninitialize` is balanced per call and torn down only when the call actually took the COM reference (`RPC_E_CHANGED_MODE` means COM is already up in another apartment: usable, but not ours to release).
- **Fail-fast:** the encoder is created before the decode, so a missing/unusable HEIC codec is rejected before any decode/resize work is wasted.
- **Public API hardening (all platforms):** the `quality` range check was promoted from a debug-only `assert` to a runtime `ArgumentError` (1–100), so an out-of-range quality fails loudly and uniformly rather than silently passing through in release builds.

## Testing

- The existing integration suite (`example/integration_test/app_test.dart`) runs on the Windows CI job (`-d windows`): JPEG/PNG conversion, resize modes, quality, and the full source-pixel-format suite (8/16-bit grayscale/RGB/RGBA, alpha preserved through resize, indexed-palette, 16-bit no-resize).
- `quality` validation is covered by a unit test (`test/quality_validation_test.dart`); the unit suite now runs via `flutter test`.
- **HEIC output is not asserted on CI:** GitHub-hosted Windows runners don't ship the HEVC/HEIF codec (`CreateEncoder` → `0x88982F8B`), so the codec-dependent path can only be exercised on machines that have it. The COM/FFI layer (vtable indices, signatures, struct offsets, GUID byte-order, release ordering, `CoUninitialize` balance) was verified against the SDK headers.
