### PR TITLE
refactor(android): import value types directly in the stub

### DIFF
--- a/lib/src/android/stub.dart
+++ b/lib/src/android/stub.dart
@@ -1,7 +1,8 @@
 import 'dart:typed_data';
 
-import 'package:platform_image_converter/platform_image_converter.dart';
 import 'package:platform_image_converter/src/image_converter_platform_interface.dart';
+import 'package:platform_image_converter/src/output_format.dart';
+import 'package:platform_image_converter/src/output_resize.dart';
 
 final class ImageConverterAndroid implements ImageConverterPlatform {
   const ImageConverterAndroid();


### PR DESCRIPTION
## What

`lib/src/android/stub.dart` imported the public barrel `platform_image_converter.dart` to obtain `OutputFormat` / `ResizeMode` / `OriginalResizeMode`. The other four stubs (darwin/linux/web/windows) import the granular `src/output_format.dart` and `src/output_resize.dart` directly.

## Why

The barrel re-exports those types, so the result was functionally equivalent — but it diverged from the other stubs and, because the barrel imports `src/android/shared.dart` which conditionally exports this very stub, it introduced a circular import:

`platform_image_converter.dart` → `src/android/shared.dart` → `src/android/stub.dart` → `platform_image_converter.dart`

Dart permits circular library imports, so this compiled and analyzed clean, but the stub only needs three value types — depending on the whole public API was unintended and unnecessary coupling.

## Change

Switch to the same granular imports the other stubs use. No behavior change.

- `flutter analyze`: No issues found
- `dart format`: unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)