### PR TITLE
refactor: adopt switch expressions and dot shorthands

### DIFF
--- a/lib/platform_image_converter.dart
+++ b/lib/platform_image_converter.dart
@@ -77,10 +77,10 @@ class ImageConverter {
   /// ```
   static Future<Uint8List> convert({
     required Uint8List inputData,
-    OutputFormat format = OutputFormat.jpeg,
+    OutputFormat format = .jpeg,
     int quality = 100,
     ResizeMode resizeMode = const OriginalResizeMode(),
-    ExifOrientationPolicy orientation = ExifOrientationPolicy.apply,
+    ExifOrientationPolicy orientation = .apply,
     bool runInIsolate = true,
   }) async {
     if (quality < 1 || quality > 100) {
@@ -118,10 +118,10 @@ ImageConverterPlatform _getPlatformForTarget(TargetPlatform platform) {
     return const ImageConverterWeb();
   }
   return switch (platform) {
-    TargetPlatform.android => const ImageConverterAndroid(),
-    TargetPlatform.iOS || TargetPlatform.macOS => const ImageConverterDarwin(),
-    TargetPlatform.windows => const ImageConverterWindows(),
-    TargetPlatform.linux => const ImageConverterLinux(),
+    .android => const ImageConverterAndroid(),
+    .iOS || .macOS => const ImageConverterDarwin(),
+    .windows => const ImageConverterWindows(),
+    .linux => const ImageConverterLinux(),
     _ => throw UnsupportedPlatformException(platform),
   };
 }

--- a/lib/src/android/native.dart
+++ b/lib/src/android/native.dart
@@ -38,10 +38,10 @@ final class ImageConverterAndroid implements ImageConverterPlatform {
   @override
   Uint8List convert({
     required Uint8List inputData,
-    OutputFormat format = OutputFormat.jpeg,
+    OutputFormat format = .jpeg,
     int quality = 100,
     ResizeMode resizeMode = const OriginalResizeMode(),
-    ExifOrientationPolicy orientation = ExifOrientationPolicy.apply,
+    ExifOrientationPolicy orientation = .apply,
   }) {
     return using((arena) {
       final inputJBytes = JByteArray.of(inputData)..releasedBy(arena);
@@ -57,7 +57,7 @@ final class ImageConverterAndroid implements ImageConverterPlatform {
       // BitmapFactory ignores the EXIF orientation, so bake it into the pixels
       // before measuring/resizing (a no-op for ORIENTATION_NORMAL or `ignore`).
       // Resizing then operates on the oriented (display) dimensions.
-      final orientedBitmap = orientation == ExifOrientationPolicy.apply
+      final orientedBitmap = orientation == .apply
           ? _applyOrientation(arena, inputJBytes, originalBitmap)
           : originalBitmap;
 
@@ -86,13 +86,13 @@ final class ImageConverterAndroid implements ImageConverterPlatform {
       }
 
       final compressFormat = switch (format) {
-        OutputFormat.jpeg => Bitmap$CompressFormat.JPEG,
-        OutputFormat.png => Bitmap$CompressFormat.PNG,
+        .jpeg => Bitmap$CompressFormat.JPEG,
+        .png => Bitmap$CompressFormat.PNG,
         // TODO: WebP is deprecated since Android 10, consider using WebP_LOSSY or WebP_LOSSLESS
-        OutputFormat.webp => Bitmap$CompressFormat.WEBP,
-        OutputFormat.heic => throw UnsupportedFormatException(
+        .webp => Bitmap$CompressFormat.WEBP,
+        .heic => throw UnsupportedFormatException(
           format,
-          UnsupportedFormatReason.platformUnsupported,
+          .platformUnsupported,
           'HEIC output is not supported on Android.',
         ),
       }..releasedBy(arena);

--- a/lib/src/android/stub.dart
+++ b/lib/src/android/stub.dart
@@ -11,9 +11,9 @@ final class ImageConverterAndroid implements ImageConverterPlatform {
   @override
   Uint8List convert({
     required Uint8List inputData,
-    OutputFormat format = OutputFormat.jpeg,
+    OutputFormat format = .jpeg,
     int quality = 100,
     ResizeMode resizeMode = const OriginalResizeMode(),
-    ExifOrientationPolicy orientation = ExifOrientationPolicy.apply,
+    ExifOrientationPolicy orientation = .apply,
   }) => throw UnimplementedError();
 }

--- a/lib/src/darwin/native.dart
+++ b/lib/src/darwin/native.dart
@@ -195,7 +195,15 @@ final class ImageConverterDarwin implements ImageConverterPlatform {
     OutputFormat format,
     int quality,
   ) {
-    if (format == .png || format == .webp) {
+    // PNG is lossless and WebP is unsupported on this backend; neither carries
+    // a lossy compression-quality dictionary. Exhaustive over OutputFormat so a
+    // future format forces a decision here instead of silently being treated as
+    // lossy.
+    final isLossy = switch (format) {
+      .jpeg || .heic => true,
+      .png || .webp => false,
+    };
+    if (!isLossy) {
       return null;
     }
 

--- a/lib/src/darwin/native.dart
+++ b/lib/src/darwin/native.dart
@@ -199,12 +199,11 @@ final class ImageConverterDarwin implements ImageConverterPlatform {
     // a lossy compression-quality dictionary. Exhaustive over OutputFormat so a
     // future format forces a decision here instead of silently being treated as
     // lossy.
-    final isLossy = switch (format) {
-      .jpeg || .heic => true,
-      .png || .webp => false,
-    };
-    if (!isLossy) {
-      return null;
+    switch (format) {
+      case .png || .webp:
+        return null;
+      case .jpeg || .heic:
+        break;
     }
 
     final keys = arena<CFStringRef>(1);

--- a/lib/src/darwin/native.dart
+++ b/lib/src/darwin/native.dart
@@ -49,10 +49,10 @@ final class ImageConverterDarwin implements ImageConverterPlatform {
   @override
   Uint8List convert({
     required Uint8List inputData,
-    OutputFormat format = OutputFormat.jpeg,
+    OutputFormat format = .jpeg,
     int quality = 100,
     ResizeMode resizeMode = const OriginalResizeMode(),
-    ExifOrientationPolicy orientation = ExifOrientationPolicy.apply,
+    ExifOrientationPolicy orientation = .apply,
   }) {
     return using((arena) {
       final inputPtr = arena<Uint8>(inputData.length);
@@ -88,7 +88,7 @@ final class ImageConverterDarwin implements ImageConverterPlatform {
       final rawHeight = CGImageGetHeight(originalImage);
 
       // EXIF orientation: 1 (no transform) when ignoring it or when absent.
-      final exifOrientation = orientation == ExifOrientationPolicy.apply
+      final exifOrientation = orientation == .apply
           ? _readOrientation(arena, imageSource)
           : 1;
 
@@ -124,15 +124,15 @@ final class ImageConverterDarwin implements ImageConverterPlatform {
 
       final utiStr = switch (format) {
         // https://developer.apple.com/documentation/uniformtypeidentifiers/uttypejpeg
-        OutputFormat.jpeg => 'public.jpeg',
+        .jpeg => 'public.jpeg',
         // https://developer.apple.com/documentation/uniformtypeidentifiers/uttypepng
-        OutputFormat.png => 'public.png',
+        .png => 'public.png',
         // https://developer.apple.com/documentation/uniformtypeidentifiers/uttypeheic
-        OutputFormat.heic => 'public.heic',
+        .heic => 'public.heic',
         // https://developer.apple.com/documentation/uniformtypeidentifiers/uttypewebp
-        OutputFormat.webp => throw UnsupportedFormatException(
+        .webp => throw UnsupportedFormatException(
           format,
-          UnsupportedFormatReason.platformUnsupported,
+          .platformUnsupported,
           'WebP output is not supported on iOS/macOS via ImageIO.',
         ),
       };
@@ -195,7 +195,7 @@ final class ImageConverterDarwin implements ImageConverterPlatform {
     OutputFormat format,
     int quality,
   ) {
-    if (format == OutputFormat.png || format == OutputFormat.webp) {
+    if (format == .png || format == .webp) {
       return null;
     }
 

--- a/lib/src/darwin/stub.dart
+++ b/lib/src/darwin/stub.dart
@@ -11,9 +11,9 @@ final class ImageConverterDarwin implements ImageConverterPlatform {
   @override
   Uint8List convert({
     required Uint8List inputData,
-    OutputFormat format = OutputFormat.jpeg,
+    OutputFormat format = .jpeg,
     int quality = 100,
     ResizeMode resizeMode = const OriginalResizeMode(),
-    ExifOrientationPolicy orientation = ExifOrientationPolicy.apply,
+    ExifOrientationPolicy orientation = .apply,
   }) => throw UnimplementedError();
 }

--- a/lib/src/image_conversion_exception.dart
+++ b/lib/src/image_conversion_exception.dart
@@ -81,9 +81,9 @@ class UnsupportedFormatException extends ImageConversionException {
     OutputFormat format,
     UnsupportedFormatReason reason,
   ) => switch (reason) {
-    UnsupportedFormatReason.platformUnsupported =>
+    .platformUnsupported =>
       '${format.name} output is not supported on this platform.',
-    UnsupportedFormatReason.codecUnavailable =>
+    .codecUnavailable =>
       '${format.name} output requires a codec that is not available in this '
           'environment.',
   };

--- a/lib/src/image_converter_platform_interface.dart
+++ b/lib/src/image_converter_platform_interface.dart
@@ -41,10 +41,10 @@ abstract interface class ImageConverterPlatform {
   /// - [ImageConversionException]: For other general errors during the conversion process.
   FutureOr<Uint8List> convert({
     required Uint8List inputData,
-    OutputFormat format = OutputFormat.jpeg,
+    OutputFormat format = .jpeg,
     int quality = 100,
     ResizeMode resizeMode = const OriginalResizeMode(),
-    ExifOrientationPolicy orientation = ExifOrientationPolicy.apply,
+    ExifOrientationPolicy orientation = .apply,
   }) {
     throw UnimplementedError('convert() has not been implemented.');
   }

--- a/lib/src/linux/native.dart
+++ b/lib/src/linux/native.dart
@@ -203,8 +203,13 @@ final class ImageConverterLinux implements ImageConverterPlatform {
     OutputFormat format,
     int quality,
   ) {
-    if (format == .png) {
-      return (nullptr, nullptr);
+    // Exhaustive over OutputFormat so a future format forces a decision here
+    // instead of silently receiving a `quality` option it may not accept.
+    switch (format) {
+      case .png:
+        return (nullptr, nullptr);
+      case .jpeg || .webp || .heic:
+        break;
     }
     final keys = arena<Pointer<Char>>(2);
     keys[0] = 'quality'.toNativeUtf8(allocator: arena).cast();

--- a/lib/src/linux/native.dart
+++ b/lib/src/linux/native.dart
@@ -24,10 +24,10 @@ extension on Pointer<Opaque> {
 /// GdkPixbuf encoder type name for each [OutputFormat]. GdkPixbuf names the
 /// HEIF/HEIC handler `heif`.
 String _typeName(OutputFormat format) => switch (format) {
-  OutputFormat.jpeg => 'jpeg',
-  OutputFormat.png => 'png',
-  OutputFormat.webp => 'webp',
-  OutputFormat.heic => 'heif',
+  .jpeg => 'jpeg',
+  .png => 'png',
+  .webp => 'webp',
+  .heic => 'heif',
 };
 
 /// Linux image converter using GdkPixbuf from the GLib/GTK stack.
@@ -48,10 +48,10 @@ final class ImageConverterLinux implements ImageConverterPlatform {
   @override
   Uint8List convert({
     required Uint8List inputData,
-    OutputFormat format = OutputFormat.jpeg,
+    OutputFormat format = .jpeg,
     int quality = 100,
     ResizeMode resizeMode = const OriginalResizeMode(),
-    ExifOrientationPolicy orientation = ExifOrientationPolicy.apply,
+    ExifOrientationPolicy orientation = .apply,
   }) {
     final type = _typeName(format);
 
@@ -63,7 +63,7 @@ final class ImageConverterLinux implements ImageConverterPlatform {
     if (!_hasWritableLoader(type)) {
       throw UnsupportedFormatException(
         format,
-        UnsupportedFormatReason.codecUnavailable,
+        .codecUnavailable,
         '${format.name} output is unavailable on this system: no writable '
         'GdkPixbuf loader for "$type" is installed.',
       );
@@ -108,7 +108,7 @@ final class ImageConverterLinux implements ImageConverterPlatform {
       // evaluated against the oriented (display) dimensions, matching the other
       // backends. With `ignore` we skip it and keep the raw buffer layout.
       var oriented = decoded;
-      if (orientation == ExifOrientationPolicy.apply) {
+      if (orientation == .apply) {
         oriented = gdk_pixbuf_apply_embedded_orientation(decoded)
           ..unrefBy(arena);
         if (oriented == nullptr) {
@@ -203,7 +203,7 @@ final class ImageConverterLinux implements ImageConverterPlatform {
     OutputFormat format,
     int quality,
   ) {
-    if (format == OutputFormat.png) {
+    if (format == .png) {
       return (nullptr, nullptr);
     }
     final keys = arena<Pointer<Char>>(2);

--- a/lib/src/linux/stub.dart
+++ b/lib/src/linux/stub.dart
@@ -11,9 +11,9 @@ final class ImageConverterLinux implements ImageConverterPlatform {
   @override
   Uint8List convert({
     required Uint8List inputData,
-    OutputFormat format = OutputFormat.jpeg,
+    OutputFormat format = .jpeg,
     int quality = 100,
     ResizeMode resizeMode = const OriginalResizeMode(),
-    ExifOrientationPolicy orientation = ExifOrientationPolicy.apply,
+    ExifOrientationPolicy orientation = .apply,
   }) => throw UnimplementedError();
 }

--- a/lib/src/output_resize.dart
+++ b/lib/src/output_resize.dart
@@ -59,7 +59,7 @@ class FitResizeMode extends ResizeMode {
       (final w?, final h?) => min(w / originalWidth, h / originalHeight),
       (final w?, null) => w / originalWidth,
       (null, final h?) => h / originalHeight,
-      (null, null) => 1.0,
+      _ => 1.0,
     };
 
     if (scale >= 1.0) {

--- a/lib/src/output_resize.dart
+++ b/lib/src/output_resize.dart
@@ -55,16 +55,12 @@ class FitResizeMode extends ResizeMode {
 
   @override
   (int, int) calculateSize(int originalWidth, int originalHeight) {
-    double scale = 1.0;
-    if (width != null && height != null) {
-      final widthScale = width! / originalWidth;
-      final heightScale = height! / originalHeight;
-      scale = min(widthScale, heightScale);
-    } else if (width != null) {
-      scale = width! / originalWidth;
-    } else if (height != null) {
-      scale = height! / originalHeight;
-    }
+    final scale = switch ((width, height)) {
+      (final w?, final h?) => min(w / originalWidth, h / originalHeight),
+      (final w?, null) => w / originalWidth,
+      (null, final h?) => h / originalHeight,
+      (null, null) => 1.0,
+    };
 
     if (scale >= 1.0) {
       return (originalWidth, originalHeight);

--- a/lib/src/web/stub.dart
+++ b/lib/src/web/stub.dart
@@ -11,9 +11,9 @@ final class ImageConverterWeb implements ImageConverterPlatform {
   @override
   Uint8List convert({
     required Uint8List inputData,
-    OutputFormat format = OutputFormat.jpeg,
+    OutputFormat format = .jpeg,
     int quality = 100,
     ResizeMode resizeMode = const OriginalResizeMode(),
-    ExifOrientationPolicy orientation = ExifOrientationPolicy.apply,
+    ExifOrientationPolicy orientation = .apply,
   }) => throw UnimplementedError();
 }

--- a/lib/src/web/web.dart
+++ b/lib/src/web/web.dart
@@ -41,10 +41,10 @@ final class ImageConverterWeb implements ImageConverterPlatform {
   @override
   Future<Uint8List> convert({
     required Uint8List inputData,
-    OutputFormat format = OutputFormat.jpeg,
+    OutputFormat format = .jpeg,
     int quality = 100,
     ResizeMode resizeMode = const OriginalResizeMode(),
-    ExifOrientationPolicy orientation = ExifOrientationPolicy.apply,
+    ExifOrientationPolicy orientation = .apply,
   }) async {
     final blob = Blob([inputData.toJS].toJS);
 
@@ -59,9 +59,7 @@ final class ImageConverterWeb implements ImageConverterPlatform {
           .createImageBitmap(
             blob,
             ImageBitmapOptions(
-              imageOrientation: orientation == ExifOrientationPolicy.apply
-                  ? 'from-image'
-                  : 'none',
+              imageOrientation: orientation == .apply ? 'from-image' : 'none',
             ),
           )
           .toDart;
@@ -86,12 +84,12 @@ final class ImageConverterWeb implements ImageConverterPlatform {
 
     final encodeCompleter = Completer<Blob>();
     final type = switch (format) {
-      OutputFormat.jpeg => 'image/jpeg',
-      OutputFormat.png => 'image/png',
-      OutputFormat.webp => 'image/webp',
-      OutputFormat.heic => throw UnsupportedFormatException(
+      .jpeg => 'image/jpeg',
+      .png => 'image/png',
+      .webp => 'image/webp',
+      .heic => throw UnsupportedFormatException(
         format,
-        UnsupportedFormatReason.platformUnsupported,
+        .platformUnsupported,
         'HEIC output is not supported on Web.',
       ),
     };

--- a/lib/src/windows/native.dart
+++ b/lib/src/windows/native.dart
@@ -51,16 +51,16 @@ final class ImageConverterWindows implements ImageConverterPlatform {
   @override
   Uint8List convert({
     required Uint8List inputData,
-    OutputFormat format = OutputFormat.jpeg,
+    OutputFormat format = .jpeg,
     int quality = 100,
     ResizeMode resizeMode = const OriginalResizeMode(),
-    ExifOrientationPolicy orientation = ExifOrientationPolicy.apply,
+    ExifOrientationPolicy orientation = .apply,
   }) {
     // Reject unsupported output before any native side effect (CoInitialize)
     if (format == .webp) {
       throw UnsupportedFormatException(
         format,
-        UnsupportedFormatReason.platformUnsupported,
+        .platformUnsupported,
         'WebP output is not supported on Windows: the OS provides a WebP '
         'decoder but no encoder.',
       );
@@ -114,7 +114,7 @@ final class ImageConverterWindows implements ImageConverterPlatform {
             encoderHr == wincodecErrComponentInitializeFailure) {
           throw UnsupportedFormatException(
             format,
-            UnsupportedFormatReason.codecUnavailable,
+            .codecUnavailable,
             '${format.name.toUpperCase()} encoding is unavailable on this '
             'Windows: the required codec is not available. HEIC needs the '
             'HEVC/HEIF codec (Windows 11 22H2+ ships it; older Windows can '
@@ -170,7 +170,7 @@ final class ImageConverterWindows implements ImageConverterPlatform {
         // EXIF orientation: 1 (identity) when ignoring it or when absent. WIC
         // does not auto-apply it, so the tag is read here and baked into the
         // pixels with an IWICBitmapFlipRotator below.
-        final exifOrientation = orientation == ExifOrientationPolicy.apply
+        final exifOrientation = orientation == .apply
             ? _readOrientation(arena, frame)
             : 1;
 

--- a/lib/src/windows/stub.dart
+++ b/lib/src/windows/stub.dart
@@ -11,9 +11,9 @@ final class ImageConverterWindows implements ImageConverterPlatform {
   @override
   Uint8List convert({
     required Uint8List inputData,
-    OutputFormat format = OutputFormat.jpeg,
+    OutputFormat format = .jpeg,
     int quality = 100,
     ResizeMode resizeMode = const OriginalResizeMode(),
-    ExifOrientationPolicy orientation = ExifOrientationPolicy.apply,
+    ExifOrientationPolicy orientation = .apply,
   }) => throw UnimplementedError();
 }


### PR DESCRIPTION
Style cleanup adopting modern Dart idioms across the backends. **No behavior change** (no version bump).

## Changes

- **Dot shorthands** for the package's own enums (`OutputFormat`, `ExifOrientationPolicy`, `UnsupportedFormatReason`, `TargetPlatform`) wherever the context type is known:
  - switch case patterns (`.jpeg => …`)
  - `==` comparisons (`format == .webp`, `orientation == .apply`)
  - `UnsupportedFormatException` `reason` arguments (`.platformUnsupported`, `.codecUnavailable`)
  - the platform dispatcher (`.android => …`)
  - parameter defaults (`OutputFormat format = .jpeg`, `ExifOrientationPolicy orientation = .apply`)
- **`switch` expression** for `FitResizeMode.calculateSize`: the scale `if`/`else if` chain becomes a `switch` over a `(width, height)` record pattern, which also removes the `!` null assertions.

JNI/COM members (e.g. `Bitmap$CompressFormat.JPEG`, `ExifInterface.ORIENTATION_NORMAL`) and dartdoc references are left fully qualified. Generated bindings are untouched.

## Verification

- `flutter analyze`: clean
- Unit tests: 26/26
- macOS integration: 35/35 (all eight EXIF orientations + `ignore` unchanged)

Net diff: 65 insertions / 71 deletions across 14 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)