### PR TITLE
fix: clamp resize output to >=1px and release Darwin encode-options dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.3
+
+* Fix a memory leak on iOS/macOS: the `CFDictionary` holding the JPEG/HEIC compression quality was created but never released, leaking one dictionary per lossy conversion. It is now released together with the surrounding arena.
+* Guarantee resize output is at least 1x1px. An extreme aspect ratio could round a dimension down to 0 (for example fitting a 4000x3 image to width 5), producing a zero-sized surface that the native encoders reject; `ResizeMode.calculateSize` now clamps both dimensions to a minimum of 1px across every resize mode and platform.
+
 ## 2.1.2
 
 * Restore the `jni` dependency to `^1.0.0` (and the Android bindings generated with `jnigen` 0.16.0), reverting the temporary downgrade shipped in 2.1.1. Projects that also depend on packages still on `jni` 0.15.x (such as `cronet_http`) will keep resolving to 2.1.1 automatically until those packages migrate.

--- a/lib/src/darwin/native.dart
+++ b/lib/src/darwin/native.dart
@@ -187,9 +187,9 @@ final class ImageConverterDarwin implements ImageConverterPlatform {
   }
 
   /// Builds the encoding options dictionary, or `null` for formats without
-  /// options (PNG/WebP). The quality [CFNumberRef] is registered in [arena]
-  /// (the caller's) so it outlives the dictionary's use during encoding; the
-  /// dictionary itself is returned for the caller to register.
+  /// options (PNG/WebP). Both the dictionary and its quality [CFNumberRef] are
+  /// registered in [arena] (the caller's), so they are released when it drains —
+  /// after the dictionary's use during encoding.
   CFDictionaryRef? _createPropertiesForFormat(
     Arena arena,
     OutputFormat format,
@@ -223,7 +223,9 @@ final class ImageConverterDarwin implements ImageConverterPlatform {
     values[0] = number.cast<Void>();
 
     // Null callbacks: the dictionary neither retains nor releases its key/value
-    // (their lifetimes are managed by the arena).
+    // (their lifetimes are managed by the arena). Register the dictionary in the
+    // arena too, beside its CFNumber — `releasedBy` skips a nullptr, so a failed
+    // create is still returned for the caller's null check.
     return CFDictionaryCreate(
       kCFAllocatorDefault,
       keys.cast(),
@@ -231,7 +233,7 @@ final class ImageConverterDarwin implements ImageConverterPlatform {
       1,
       nullptr,
       nullptr,
-    );
+    )..releasedBy(arena);
   }
 
   /// Draws [originalImage] into a fixed 8-bpc sRGB premultiplied-RGBA context

--- a/lib/src/output_resize.dart
+++ b/lib/src/output_resize.dart
@@ -5,7 +5,21 @@ sealed class ResizeMode {
   const ResizeMode();
 
   /// Calculates the target size for the image based on the original dimensions.
-  (int, int) calculateSize(int originalWidth, int originalHeight);
+  ///
+  /// The returned width and height are clamped to a minimum of 1px. An extreme
+  /// aspect ratio can otherwise round a side down to 0 — fitting a 4000x3 image
+  /// to width 5 yields a height of `round(3 * 5 / 4000) == 0` — and every native
+  /// encoder rejects a zero-sized surface. Clamping here keeps that invariant in
+  /// one place for all modes, including release builds where the subclasses'
+  /// positive-dimension asserts are stripped.
+  (int, int) calculateSize(int originalWidth, int originalHeight) {
+    final (width, height) = _computeSize(originalWidth, originalHeight);
+    return (max(1, width), max(1, height));
+  }
+
+  /// The unclamped target size for this mode; [calculateSize] applies the
+  /// minimum-dimension clamp around it.
+  (int, int) _computeSize(int originalWidth, int originalHeight);
 }
 
 /// A resize mode that keeps the original dimensions of the image.
@@ -13,7 +27,7 @@ class OriginalResizeMode extends ResizeMode {
   const OriginalResizeMode();
 
   @override
-  (int, int) calculateSize(int originalWidth, int originalHeight) {
+  (int, int) _computeSize(int originalWidth, int originalHeight) {
     return (originalWidth, originalHeight);
   }
 }
@@ -31,7 +45,7 @@ class ExactResizeMode extends ResizeMode {
   final int height;
 
   @override
-  (int, int) calculateSize(int originalWidth, int originalHeight) {
+  (int, int) _computeSize(int originalWidth, int originalHeight) {
     return (width, height);
   }
 }
@@ -54,7 +68,7 @@ class FitResizeMode extends ResizeMode {
   final int? height;
 
   @override
-  (int, int) calculateSize(int originalWidth, int originalHeight) {
+  (int, int) _computeSize(int originalWidth, int originalHeight) {
     final scale = switch ((width, height)) {
       (final w?, final h?) => min(w / originalWidth, h / originalHeight),
       (final w?, null) => w / originalWidth,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: platform_image_converter
 description: "A high-performance Flutter plugin for cross-platform image format conversion using native APIs."
-version: 2.1.2
+version: 2.1.3
 homepage: https://github.com/koji-1009/platform_image_converter
 topics:
   - image

--- a/test/output_resize_test.dart
+++ b/test/output_resize_test.dart
@@ -137,5 +137,35 @@ void main() {
       expect(() => FitResizeMode(width: 0), throwsA(isA<AssertionError>()));
       expect(() => FitResizeMode(height: -5), throwsA(isA<AssertionError>()));
     });
+
+    // An extreme aspect ratio rounds one side down to round(3 * 5 / 4000) == 0,
+    // which the native encoders reject. calculateSize clamps each dimension
+    // independently, so both the height side and the symmetric width side must
+    // come back as 1.
+    const clampCases = [
+      (
+        side: 'height',
+        mode: FitResizeMode(width: 5),
+        w: 4000,
+        h: 3,
+        expW: 5,
+        expH: 1,
+      ),
+      (
+        side: 'width',
+        mode: FitResizeMode(height: 5),
+        w: 3,
+        h: 4000,
+        expW: 1,
+        expH: 5,
+      ),
+    ];
+    for (final c in clampCases) {
+      test('FitResizeMode clamps a rounded-to-zero ${c.side} up to 1', () {
+        final (width, height) = c.mode.calculateSize(c.w, c.h);
+        expect(width, c.expW);
+        expect(height, c.expH);
+      });
+    }
   });
 }


### PR DESCRIPTION
## Summary

Two robustness fixes in the image-conversion path, found during a deep review of the convert pipeline.

### 1. Resize can produce a zero dimension
`ResizeMode.calculateSize` could return a 0-length side for extreme aspect ratios — e.g. `FitResizeMode(width: 5)` on a 4000x3 image rounds the height to `round(3 * 5 / 4000) == 0`. `ExactResizeMode` only guards this with an `assert`, which is stripped in release builds, so a 0 could reach the native encoders (which reject a zero-sized surface, with inconsistent per-platform errors).

The fix clamps both dimensions to a minimum of 1px in the shared `ResizeMode.calculateSize`, so every mode and backend honors the invariant in one place. The clamp is added via a template method (`_computeSize`) so each subclass keeps its raw calculation.

### 2. Darwin leaks the encode-options CFDictionary
On iOS/macOS, the `CFDictionary` holding the lossy compression quality (JPEG/HEIC) was created with `CFDictionaryCreate` but never `CFRelease`d — leaking one dictionary per lossy conversion. Because FFI/CoreFoundation allocations live in the process-global native heap, the leak is not reclaimed when the `compute` isolate tears down. It is now registered in the arena alongside its `CFNumber`.

## Tests
- New unit tests cover the rounded-to-zero clamp on both the height and width sides.
- `flutter analyze` clean, `flutter test` green (28 tests), `dart format` clean.

## Notes
- The Darwin leak fix is exercised by the existing Darwin integration tests (no crash); the leak itself is not separately measured in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
