### PR TITLE
test: add unit tests for the Darwin and Windows EXIF orientation transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Add host-runnable unit tests for the EXIF orientation transforms on the Darwin and Windows backends. The pure transform functions are exposed via `@visibleForTesting` and covered by tests that pin the CoreGraphics affine matrix (all eight orientations, plus a scaled case) and the WIC `WICBitmapTransformOptions` mapping, so a regression in that math is caught on the unit-test runner without a device or simulator. No behavior change.
+
 ## 2.1.3
 
 * Fix a memory leak on iOS/macOS: the `CFDictionary` holding the JPEG/HEIC compression quality was created but never released, leaking one dictionary per lossy conversion. It is now released together with the surrounding arena.

--- a/lib/src/darwin/native.dart
+++ b/lib/src/darwin/native.dart
@@ -2,6 +2,7 @@ import 'dart:ffi';
 import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:platform_image_converter/src/darwin/apple_cf_types.dart';
 import 'package:platform_image_converter/src/darwin/bindings.g.dart';
 import 'package:platform_image_converter/src/exif_orientation_policy.dart';
@@ -286,13 +287,7 @@ final class ImageConverterDarwin implements ImageConverterPlatform {
     // orientation 1, so the non-oriented path is unchanged.
     CGContextConcatCTM(
       context,
-      _orientationTransform(
-        exifOrientation,
-        rawWidth,
-        rawHeight,
-        width,
-        height,
-      ),
+      orientationTransform(exifOrientation, rawWidth, rawHeight, width, height),
     );
 
     final rect = Struct.create<CGRect>()
@@ -346,7 +341,10 @@ final class ImageConverterDarwin implements ImageConverterPlatform {
   /// the context's bottom-left, y-up space (identity reproduces the input). The
   /// four corners of the raw box are mapped to find the translation that seats
   /// the result in the positive quadrant; the scale to the output is folded in.
-  CGAffineTransform _orientationTransform(
+  ///
+  /// Pure math (no native call), so it is exposed for host unit testing.
+  @visibleForTesting
+  CGAffineTransform orientationTransform(
     int orientation,
     int rawWidth,
     int rawHeight,

--- a/lib/src/windows/native.dart
+++ b/lib/src/windows/native.dart
@@ -2,6 +2,7 @@ import 'dart:ffi';
 import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:platform_image_converter/src/exif_orientation_policy.dart';
 import 'package:platform_image_converter/src/image_conversion_exception.dart';
 import 'package:platform_image_converter/src/image_converter_platform_interface.dart';
@@ -217,7 +218,7 @@ final class ImageConverterWindows implements ImageConverterPlatform {
         // rotation; [_orientationTransform] encodes that. Identity (orientation
         // 1) skips the rotator entirely, leaving the non-oriented path unchanged.
         var source = converter;
-        final transform = _orientationTransform(exifOrientation);
+        final transform = orientationTransform(exifOrientation);
         if (transform != wicBitmapTransformRotate0) {
           final pRotator = arena<Pointer<Void>>();
           if (wicCreateBitmapFlipRotator(factory, pRotator) != sOk) {
@@ -387,7 +388,10 @@ final class ImageConverterWindows implements ImageConverterPlatform {
   /// (verified by the corner mapping — flip-first yields the transpose for 5 and
   /// the transverse for 7). Returns [wicBitmapTransformRotate0] (identity) for 1
   /// and any unexpected value, so the caller skips the rotator.
-  int _orientationTransform(int orientation) => switch (orientation) {
+  ///
+  /// Pure mapping (no native call), so it is exposed for host unit testing.
+  @visibleForTesting
+  int orientationTransform(int orientation) => switch (orientation) {
     2 => wicBitmapTransformFlipHorizontal,
     3 => wicBitmapTransformRotate180,
     4 => wicBitmapTransformFlipVertical,

--- a/test/darwin_orientation_transform_test.dart
+++ b/test/darwin_orientation_transform_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_image_converter/src/darwin/native.dart';
+
+void main() {
+  // `orientationTransform` is pure math returning a managed `CGAffineTransform`
+  // (no native call), so it runs on the host unit-test runner. It pins the
+  // CoreGraphics CTM that bakes each EXIF orientation while scaling the raw image
+  // onto the oriented output box. The integration test validates the resulting
+  // pixels against an oracle; this fixes the matrix itself so a refactor cannot
+  // silently change it. raw is a non-square 64x32 so the axis swap of the 90/270
+  // rotations (orientations 5-8) is observable.
+  const converter = ImageConverterDarwin();
+  const rawW = 64;
+  const rawH = 32;
+
+  // (orientation, outW, outH, [a, b, c, d, tx, ty]). Orientations 1-4 keep the
+  // raw dimensions; the axis-swapping 5-8 receive swapped output dimensions
+  // (as the real caller does), so the transform fills the oriented box exactly.
+  const cases = <(int, int, int, List<double>)>[
+    (1, 64, 32, [1, 0, 0, 1, 0, 0]),
+    (2, 64, 32, [-1, 0, 0, 1, 64, 0]),
+    (3, 64, 32, [-1, 0, 0, -1, 64, 32]),
+    (4, 64, 32, [1, 0, 0, -1, 0, 32]),
+    (5, 32, 64, [0, -1, -1, 0, 32, 64]),
+    (6, 32, 64, [0, -1, 1, 0, 0, 64]),
+    (7, 32, 64, [0, 1, 1, 0, 0, 0]),
+    (8, 32, 64, [0, 1, -1, 0, 32, 0]),
+  ];
+
+  for (final (orientation, outW, outH, e) in cases) {
+    test('orientation $orientation builds its oriented, box-filling CTM', () {
+      final t = converter.orientationTransform(
+        orientation,
+        rawW,
+        rawH,
+        outW,
+        outH,
+      );
+      expect(t.a, closeTo(e[0], 1e-9), reason: 'a');
+      expect(t.b, closeTo(e[1], 1e-9), reason: 'b');
+      expect(t.c, closeTo(e[2], 1e-9), reason: 'c');
+      expect(t.d, closeTo(e[3], 1e-9), reason: 'd');
+      expect(t.tx, closeTo(e[4], 1e-9), reason: 'tx');
+      expect(t.ty, closeTo(e[5], 1e-9), reason: 'ty');
+    });
+  }
+
+  test('an unmapped orientation falls back to identity', () {
+    final t = converter.orientationTransform(99, rawW, rawH, rawW, rawH);
+    expect(t.a, closeTo(1, 1e-9));
+    expect(t.b, closeTo(0, 1e-9));
+    expect(t.c, closeTo(0, 1e-9));
+    expect(t.d, closeTo(1, 1e-9));
+    expect(t.tx, closeTo(0, 1e-9));
+    expect(t.ty, closeTo(0, 1e-9));
+  });
+
+  test('a downscale folds the scale into the orientation CTM', () {
+    // Orientation 1 with the output halved: the identity linear part is scaled
+    // by 0.5 on both axes, with no translation.
+    final t = converter.orientationTransform(1, rawW, rawH, 32, 16);
+    expect(t.a, closeTo(0.5, 1e-9));
+    expect(t.d, closeTo(0.5, 1e-9));
+    expect(t.tx, closeTo(0, 1e-9));
+    expect(t.ty, closeTo(0, 1e-9));
+  });
+}

--- a/test/windows_orientation_transform_test.dart
+++ b/test/windows_orientation_transform_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_image_converter/src/windows/native.dart';
+
+void main() {
+  // `orientationTransform` is a pure mapping (no native/COM call), so it runs on
+  // the host unit-test runner even though the rest of the Windows backend needs
+  // WIC. Pins the EXIF-orientation -> WICBitmapTransformOptions mapping so a
+  // regression (e.g. swapping the transpose/transverse pair) is caught without a
+  // Windows machine. The per-bit constants below are from wincodec.h: rotations
+  // occupy the low two bits, the two flips are independent flag bits.
+  const rotate0 = 0x0;
+  const rotate90 = 0x1;
+  const rotate180 = 0x2;
+  const rotate270 = 0x3;
+  const flipHorizontal = 0x8;
+  const flipVertical = 0x10;
+
+  const converter = ImageConverterWindows();
+
+  const expected = <int, int>{
+    1: rotate0,
+    2: flipHorizontal,
+    3: rotate180,
+    4: flipVertical,
+    5: flipHorizontal | rotate270,
+    6: rotate90,
+    7: flipHorizontal | rotate90,
+    8: rotate270,
+  };
+
+  expected.forEach((orientation, options) {
+    test('orientation $orientation maps to its WIC transform options', () {
+      expect(converter.orientationTransform(orientation), options);
+    });
+  });
+
+  for (final invalid in const [0, 9, -1, 100]) {
+    test('out-of-range orientation $invalid falls back to Rotate0', () {
+      expect(converter.orientationTransform(invalid), rotate0);
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Expands unit-test coverage for the most intricate pure logic in the conversion path: the per-backend EXIF orientation transforms. Until now this math was exercised only end-to-end by the on-device integration tests; this adds host-runnable unit tests that pin it directly.

- **Darwin** (`orientationTransform`): builds the CoreGraphics affine matrix that bakes an EXIF orientation while scaling the raw image onto the oriented output box. The test pins all eight orientations (using a non-square 64x32 source so the 90/270 axis swap is observable), the identity fallback for an unmapped value, and a downscale case (scale folded into the CTM).
- **Windows** (`orientationTransform`): maps an EXIF orientation to its `WICBitmapTransformOptions`. The test pins all eight orientations (including the flip+rotate pairs) plus the out-of-range fallback to `Rotate0`.

Both helpers were previously private; they are now exposed via `@visibleForTesting`. They are pure (no native/COM call), so the tests run on the Linux unit-test runner — no device or simulator required.

## Why
The orientation matrices are the trickiest pure logic in the package, and a refactor could silently change them while the heavy integration tests stay green only on the platforms that actually run. These unit tests catch such regressions cheaply, without multiplying the device matrix.

## Notes
- **No behavior change** — only test code plus the `@visibleForTesting` exposure.
- `pubspec.yaml` version is unchanged; the entry is recorded under a `## Unreleased` CHANGELOG section and will ride a future release.

## Tests
- `flutter analyze` clean, `flutter test` green (50 tests, +22), `dart format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
