### PR TITLE
chore: Tune the Android JNI config and output buffer

### DIFF
--- a/jnigen.yaml
+++ b/jnigen.yaml
@@ -9,8 +9,6 @@ output:
     path: lib/src/android/bindings.g.dart
     structure: single_file
 
-source_path:
-  - 'java/'
 classes:
   - 'java.io.ByteArrayOutputStream'
   - 'java.io.ByteArrayInputStream'

--- a/lib/src/android/native.dart
+++ b/lib/src/android/native.dart
@@ -96,7 +96,15 @@ final class ImageConverterAndroid implements ImageConverterPlatform {
         );
       }
 
-      return Uint8List.fromList(outputJBytes.getRange(0, outputJBytes.length));
+      // `getRange` copies the encoded bytes into a native buffer it takes from
+      // the allocator. With the default (`malloc`) it attaches a NativeFinalizer
+      // and that buffer — as large as the output image — lives until the Dart GC
+      // runs it. Taking it from [arena] instead drops the finalizer and frees it
+      // when this scope ends; the copy into the returned [Uint8List] happens
+      // first, so nothing outlives the arena.
+      return Uint8List.fromList(
+        outputJBytes.getRange(0, outputJBytes.length, allocator: arena),
+      );
     });
   }
 


### PR DESCRIPTION
## What

Two small follow-ups found while reviewing what the jnigen 0.17.0 / ffigen 21.0.0 upgrade
changed.

**Drop the dead `source_path` entry from `jnigen.yaml`.** It pointed at a `java/` directory that
does not exist here. Removing it regenerates `lib/src/android/bindings.g.dart` byte-for-byte
identically.

**Free the JNI output buffer with the arena.** `JByteArray.getRange` copies the encoded bytes
into a native buffer taken from its allocator, and for the default `malloc` it attaches a
`NativeFinalizer` — so a buffer as large as the output image stays alive until the Dart GC runs
that finalizer. Taking it from the surrounding arena instead frees it when the scope ends;
`package:jni` only attaches a finalizer for `malloc`/`calloc`, and the copy into the returned
`Uint8List` happens inside the scope, so nothing outlives the arena.

## Verification

- Regenerating with the `source_path` entry removed produces an identical `bindings.g.dart`.
- `flutter test` 50/50 pass.
- Integration tests on an API 37 emulator: 35/35 pass.
- `dart analyze` and `dart format` clean.

## Not changed

`ImageDecoder$OnHeaderDecodedListener.implement` creates one `RawReceivePort` per `convert()`
call, and it closes only after the Java proxy becomes phantom-reachable and `PortCleaner` fires.
The arena cannot shorten that: it releases the JNI global reference, not the port, and the port
handle is a local inside the generated `implementIn` with no disposal API on `JImplementer`.
Reusing a single listener per isolate would remove it, but only helps `runInIsolate: false`, and
costs top-level mutable state — not worth it for one port and one map entry that live until the
next Java GC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
