### PR TITLE
ci: Boot the iOS simulator with boot-simctl

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -54,32 +54,16 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: koji-1009/setup-flutter@9a42a50501f6af795c1a42e2c3c371f40e8c54b2 # v1.4.0
-      - name: Select an available iPhone simulator on iOS 26.x
-        id: simulator
-        run: |
-          udid=$(xcrun simctl list devices --json \
-            | jq -r '[ .devices | to_entries[]
-                       | select(.key | contains("iOS-26-"))
-                       | .value[]
-                       | select(.isAvailable and (.name | contains("iPhone"))) ]
-                     | .[0].udid // empty')
-          if [ -z "$udid" ]; then
-            echo "::error::No available iPhone simulator found for iOS 26.x"
-            xcrun simctl list devices
-            exit 1
-          fi
-          echo "Selected iPhone simulator (iOS 26.x): $udid"
-          echo "udid=$udid" >> "$GITHUB_OUTPUT"
-      - uses: futureware-tech/simulator-action@e89aa8f93d3aec35083ff49d2854d07f7186f7f5 # v5
+      - uses: koji-1009/boot-simctl@75139bcbd39bf667f1cb4b6742a0b929676efc3b # v1.1.0
         with:
-          wait_for_boot: true
-          udid: ${{ steps.simulator.outputs.udid }}
+          device: iPhone
+          os: "26"
       - name: Pre-build the app
         working-directory: example
         run: flutter build ios --simulator --target=integration_test/app_test.dart
       - name: Run flutter integration tests
         working-directory: example
-        run: flutter test integration_test/app_test.dart -d ${{ steps.simulator.outputs.udid }}
+        run: flutter test integration_test/app_test.dart -d "$SIMULATOR_UDID"
 
   drive_macos:
     name: macOS

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -54,13 +54,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: koji-1009/setup-flutter@9a42a50501f6af795c1a42e2c3c371f40e8c54b2 # v1.4.0
-      - uses: koji-1009/boot-simctl@75139bcbd39bf667f1cb4b6742a0b929676efc3b # v1.1.0
-        with:
-          device: iPhone
-          os: "26"
-      - name: Pre-build the app
-        working-directory: example
-        run: flutter build ios --simulator --target=integration_test/app_test.dart
+      - parallel:
+          - uses: koji-1009/boot-simctl@ecc5161dd40a0854fde7591b5a11c9584fb684bf # v1.2.0
+            with:
+              device: iPhone
+              os: "26"
+          - name: Pre-build the app
+            working-directory: example
+            run: flutter build ios --simulator --target=integration_test/app_test.dart
       - name: Run flutter integration tests
         working-directory: example
         run: flutter test integration_test/app_test.dart -d "$SIMULATOR_UDID"


### PR DESCRIPTION
## What

Replace the jq selection step and `futureware-tech/simulator-action` with
[`koji-1009/boot-simctl`](https://github.com/koji-1009/boot-simctl), which picks a device and
boots it in one step. `os: "26"` covers the same 26.x range the jq filter did.

The action publishes the booted device as `SIMULATOR_UDID`, so the UDID no longer has to be
threaded through a step output.

Booting and the pre-build run as a `parallel` group. Booting is ~115s of waiting the build does
not depend on, and `flutter build ios --simulator` does not need a booted device.

## Results

iOS job, start to finish:

| | duration |
| --- | ---: |
| before this PR | 728s |
| boot, then build | 610s |
| build, then boot | 769s |
| **boot and build overlapped** | **478s** |

34% off. The step breakdown for each arrangement:

| | boot first | build first | overlapped |
| --- | ---: | ---: | ---: |
| boot | 141.7 | 225.5 | 115.1 (inside the group) |
| pre-build | 276.9 | 145.6 | 322.9 |
| test | 128.6 | 346.7 | 91.3 |

Booting first leaves the simulator resident for the whole build and costs it 131s. Building
first pushes the simulator's settling time onto the test step and costs it 218s. Overlapping
hides the boot inside the build entirely, and the simulator still gets ~200s to settle before
the tests, which come out fastest of the three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
