### PR TITLE
chore: Prepare the 2.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-## Unreleased
+## 2.2.0
 
 * Decode with `ImageDecoder` on Android 9+ (API 28) when `ExifOrientationPolicy.apply` is in effect. `setTargetSize` in the header callback scales during the decode, so a resize no longer materializes the full-resolution bitmap before `Bitmap.createScaledBitmap` shrinks it, and `ImageDecoder` bakes in the EXIF orientation itself. The `BitmapFactory` path is unchanged and still used below API 28 and for `ExifOrientationPolicy.ignore`, which `ImageDecoder` cannot express; the plugin's `minSdk` is unchanged.
 * Use the explicit `WEBP_LOSSY`/`WEBP_LOSSLESS` compress formats for WebP output on Android 11+ (API 30), where the combined `WEBP` format is deprecated. A `quality` of 100 selects `WEBP_LOSSLESS` and anything lower `WEBP_LOSSY`, which is what `WEBP` itself did, so the output is unchanged.
+* Free the Android JNI output buffer deterministically. `JByteArray.getRange` took its native buffer from `malloc` with a `NativeFinalizer` attached, so a buffer as large as the encoded output stayed alive until the Dart GC ran that finalizer. It now comes from the surrounding arena and is freed when the conversion scope ends.
+* Regenerate the bindings with `jnigen` 0.17.0 and `ffigen` 21.0.0.
 * Add host-runnable unit tests for the EXIF orientation transforms on the Darwin and Windows backends. The pure transform functions are exposed via `@visibleForTesting` and covered by tests that pin the CoreGraphics affine matrix (all eight orientations, plus a scaled case) and the WIC `WICBitmapTransformOptions` mapping, so a regression in that math is caught on the unit-test runner without a device or simulator. No behavior change.
 
 ## 2.1.3

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # platform_image_converter
 
-[![pub package](https://img.shields.io/pub/v/platform_image_converter.svg)](https://pub.dev/packages/platform_image_converter)
-[![GitHub license](https://img.shields.io/github/license/koji-1009/platform_image_converter)](https://github.com/koji-1009/platform_image_converter/blob/main/LICENSE)
+[![pub package](https://img.shields.io/pub/v/platform_image_converter.svg)](https://pub.dev/packages/platform_image_converter) [![GitHub license](https://img.shields.io/github/license/koji-1009/platform_image_converter)](https://github.com/koji-1009/platform_image_converter/blob/main/LICENSE) [![Analyze](https://img.shields.io/github/actions/workflow/status/koji-1009/platform_image_converter/analyze.yml?branch=main&label=analyze)](https://github.com/koji-1009/platform_image_converter/actions/workflows/analyze.yml) [![Integration Test](https://img.shields.io/github/actions/workflow/status/koji-1009/platform_image_converter/integration_test.yml?branch=main&label=integration%20test)](https://github.com/koji-1009/platform_image_converter/actions/workflows/integration_test.yml)
 
 A high-performance Flutter plugin for cross-platform image format conversion and resizing using native APIs on iOS, macOS, Android, Windows, Linux, and Web.
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -373,7 +373,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.3"
+    version: "2.2.0"
   plugin_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: platform_image_converter
 description: "A high-performance Flutter plugin for cross-platform image format conversion using native APIs."
-version: 2.1.3
+version: 2.2.0
 homepage: https://github.com/koji-1009/platform_image_converter
 topics:
   - image


### PR DESCRIPTION
## What

Close the `Unreleased` section as `2.2.0` and bump `pubspec.yaml` to match. Android gained the
`ImageDecoder` decode path this cycle with no breaking change, so it is a minor bump.

Two entries are added that landed without a changelog line: the JNI output buffer now freed by
the arena (#78), and the `jnigen` 0.17.0 / `ffigen` 21.0.0 regeneration (#75). CI-only changes
are left out.

Also adds Analyze and Integration Test badges to the README.

## Verification

`flutter pub publish --dry-run` reports no issues other than the working tree being dirty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
